### PR TITLE
[Feat] 검색 UI 구현

### DIFF
--- a/src/features/search-schedule/index.ts
+++ b/src/features/search-schedule/index.ts
@@ -1,0 +1,1 @@
+export { SearchSchedule } from "./ui";

--- a/src/features/search-schedule/ui/RecentSearchKeyword.tsx
+++ b/src/features/search-schedule/ui/RecentSearchKeyword.tsx
@@ -1,0 +1,44 @@
+import { Button } from "@/shared/ui";
+import { X } from "lucide-react";
+
+interface RecentSearchKeywordProps {
+  recentKeywords: string[];
+  onSearchKeyword: (keyword: string) => void;
+  onRemoveKeyword: (keyword: string) => void;
+}
+/**
+ * 최근 검색어를 최대 5개까지 보여주는 컴포넌트입니다.
+ * 최근 검색어를 클릭하면 해당 검색어로 다시 검색하고, X 버튼으로 개별 삭제할 수 있습니다.
+ */
+export const RecentSearchKeyword = ({ recentKeywords, onSearchKeyword, onRemoveKeyword }: RecentSearchKeywordProps) => {
+  return (
+    <div className="space-y-2">
+      <h3 className="pl-1 text-bold-m text-grayscale-black">최근 검색</h3>
+      <ul>
+        {recentKeywords.map((keyword, index) => (
+          <li key={`${index}-${keyword}`} className="group px-2">
+            <div className="flex items-center justify-between rounded-md px-2 py-1">
+              <button
+                type="button"
+                onClick={() => onSearchKeyword(keyword)}
+                className="min-w-0 flex-1 text-left text-grayscale-700 text-medium-r"
+              >
+                <span className="block truncate">{keyword}</span>
+              </button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={() => onRemoveKeyword(keyword)}
+                className="h-6 w-6 flex-shrink-0 hover:bg-transparent"
+                aria-label={`"${keyword}" 검색 기록 삭제`}
+              >
+                <X className="size-3 text-grayscale-400" />
+              </Button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};

--- a/src/features/search-schedule/ui/RecentSearchKeyword.tsx
+++ b/src/features/search-schedule/ui/RecentSearchKeyword.tsx
@@ -15,8 +15,8 @@ export const RecentSearchKeyword = ({ recentKeywords, onSearchKeyword, onRemoveK
     <div className="space-y-2">
       <h3 className="pl-1 text-bold-m text-grayscale-black">최근 검색</h3>
       <ul>
-        {recentKeywords.map((keyword, index) => (
-          <li key={`${index}-${keyword}`} className="group px-2">
+        {recentKeywords.map((keyword) => (
+          <li key={keyword} className="group px-2">
             <div className="flex items-center justify-between rounded-md px-2 py-1">
               <button
                 type="button"

--- a/src/features/search-schedule/ui/SearchResults.tsx
+++ b/src/features/search-schedule/ui/SearchResults.tsx
@@ -1,4 +1,3 @@
-import { Calendar } from "lucide-react";
 import type { SearchResultItem } from "./types";
 
 interface SearchResultsProps {

--- a/src/features/search-schedule/ui/SearchResults.tsx
+++ b/src/features/search-schedule/ui/SearchResults.tsx
@@ -1,0 +1,52 @@
+import { Calendar } from "lucide-react";
+import type { SearchResultItem } from "./types";
+
+interface SearchResultsProps {
+  results: SearchResultItem[];
+  isLoading?: boolean;
+}
+
+/**
+ * 검색 결과를 표시하는 컴포넌트입니다.
+ * 일정 검색 결과를 목록 형태로 보여줍니다.
+ */
+export const SearchResults = ({ results, isLoading = false }: SearchResultsProps) => {
+  if (isLoading) {
+    return <div>로딩 중...</div>;
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="text-bold-m text-grayscale-black">검색 결과 {results.length > 0 && `(${results.length}개)`}</div>
+
+      {results.length === 0 ? (
+        <div className="py-3 text-center">
+          <p className="text-grayscale-700 text-medium-r">검색 결과가 없습니다.</p>
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {results.map((result) => (
+            <li key={result.scheduleId}>
+              <div className="cursor-pointer rounded-lg border border-grayscale-300 p-3 text-grayscale-700 transition-colors hover:bg-grayscale-100">
+                <div className="space-y-1">
+                  <div className="flex items-center justify-between">
+                    <div className="text-medium-r">{result.title}</div>
+                    <div className="text-medium-s">{result.calendarName}</div>
+                  </div>
+                  <div className="flex items-center justify-between text-medium-s">
+                    <span>
+                      {result.startDate}~{result.endDate}
+                    </span>
+                    <span>
+                      {result.startTime}~{result.endTime}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/src/features/search-schedule/ui/index.tsx
+++ b/src/features/search-schedule/ui/index.tsx
@@ -1,6 +1,7 @@
 import { Button, Input } from "@/shared/ui";
-import { Search, X } from "lucide-react";
+import { Search } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { RecentSearchKeyword } from "./recentSearchKeyword";
 
 /**
  * 검색을 위한 사이드바 컴포넌트입니다.
@@ -10,23 +11,25 @@ export const SearchSchedule = () => {
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [recentSearchKeyword, setRecentSearchKeyword] = useState<string[]>([]);
 
-  const handleSearch = () => {
-    const query = searchInputRef.current?.value.trim() || "";
+  const handleSearch = (keyword?: string) => {
+    const query = keyword || searchInputRef.current?.value.trim() || "";
     if (query) {
       const filtered = recentSearchKeyword.filter((keyword) => keyword !== query);
       const updated = [query, ...filtered].slice(0, 5);
       setRecentSearchKeyword(updated);
 
       localStorage.setItem("recentSearchKeyword", updated.join(","));
+
+      if (keyword && searchInputRef.current) {
+        searchInputRef.current.value = keyword;
+      }
     }
   };
 
-  const handleRemoveKeyword = (indexToRemove: number) => {
-    setRecentSearchKeyword((prev) => {
-      const updated = prev.filter((_, index) => index !== indexToRemove);
-      localStorage.setItem("recentSearchKeyword", updated.join(","));
-      return updated;
-    });
+  const handleRemoveKeyword = (removeKeyword: string) => {
+    const updated = recentSearchKeyword.filter((val) => val !== removeKeyword);
+    setRecentSearchKeyword(updated);
+    localStorage.setItem("recentSearchKeyword", updated.join(","));
   };
 
   useEffect(() => {
@@ -47,47 +50,22 @@ export const SearchSchedule = () => {
           className="w-full rounded-lg border border-grayscale-400 p-2 outline-none focus:border-transparent focus:ring-2 focus:ring-primary-main"
           onKeyDown={(e) => e.key === "Enter" && handleSearch()}
         />
-        <Button type="button" variant="ghost" size="icon" onClick={handleSearch} className="group hover:bg-transparent">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={() => handleSearch()}
+          className="group hover:bg-transparent"
+        >
           <Search className="size-6 text-grayscale-400 transition-colors group-hover:text-primary-main" />
         </Button>
       </div>
 
-      {/* 최근 검색어 */}
-      {recentSearchKeyword.length > 0 && (
-        <div className="space-y-2">
-          <h3 className="font-medium text-grayscale-700 text-sm">최근 검색어</h3>
-          <ul className="space-y-1">
-            {recentSearchKeyword.map((keyword, index) => (
-              <li key={`${index}-${keyword}`} className="group">
-                <div className="flex items-center justify-between rounded-md p-2 transition-colors hover:bg-grayscale-50">
-                  <button
-                    type="button"
-                    onClick={() => {
-                      if (searchInputRef.current) {
-                        searchInputRef.current.value = keyword;
-                        handleSearch();
-                      }
-                    }}
-                    className="min-w-0 flex-1 text-left text-grayscale-600 text-sm transition-colors hover:text-grayscale-900"
-                  >
-                    <span className="block truncate">{keyword}</span>
-                  </button>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => handleRemoveKeyword(index)}
-                    className="h-6 w-6 flex-shrink-0 hover:bg-grayscale-100"
-                    aria-label={`"${keyword}" 검색 기록 삭제`}
-                  >
-                    <X className="size-3 text-grayscale-400" />
-                  </Button>
-                </div>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
+      <RecentSearchKeyword
+        recentKeywords={recentSearchKeyword}
+        onSearchKeyword={handleSearch}
+        onRemoveKeyword={handleRemoveKeyword}
+      />
     </div>
   );
 };

--- a/src/features/search-schedule/ui/index.tsx
+++ b/src/features/search-schedule/ui/index.tsx
@@ -1,19 +1,26 @@
 import { Button, Input } from "@/shared/ui";
 import { Search } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { SearchResults } from "./SearchResults";
 import { RecentSearchKeyword } from "./recentSearchKeyword";
+import type { SearchResultItem, ViewType } from "./types";
 
 /**
  * 검색을 위한 사이드바 컴포넌트입니다.
  * 검색어 입력 기능을 제공합니다.
  */
 export const SearchSchedule = () => {
+  const [viewType, setViewType] = useState<ViewType>("RECENT");
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [recentSearchKeyword, setRecentSearchKeyword] = useState<string[]>([]);
+  const [searchResults, setSearchResults] = useState<SearchResultItem[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
 
   const handleSearch = (keyword?: string) => {
     const query = keyword || searchInputRef.current?.value.trim() || "";
     if (query) {
+      setIsSearching(true);
+
       const filtered = recentSearchKeyword.filter((keyword) => keyword !== query);
       const updated = [query, ...filtered].slice(0, 5);
       setRecentSearchKeyword(updated);
@@ -24,6 +31,34 @@ export const SearchSchedule = () => {
         searchInputRef.current.value = keyword;
       }
     }
+
+    // TODO: 검색 API 호출
+    setTimeout(() => {
+      setSearchResults([
+        {
+          scheduleId: 12,
+          calendarId: 5,
+          calendarName: "팀 프로젝트",
+          title: "팀 회의",
+          startDate: "2025-04-01",
+          endDate: "2025-04-01",
+          startTime: "09:00",
+          endTime: "10:00",
+        },
+        {
+          scheduleId: 27,
+          calendarId: 3,
+          calendarName: "개인 캘린더",
+          title: "고객 회의",
+          startDate: "2025-04-01",
+          endDate: "2025-04-01",
+          startTime: "15:00",
+          endTime: "16:00",
+        },
+      ]);
+      setIsSearching(false);
+      setViewType("RESULT");
+    }, 500);
   };
 
   const handleRemoveKeyword = (removeKeyword: string) => {
@@ -61,11 +96,15 @@ export const SearchSchedule = () => {
         </Button>
       </div>
 
-      <RecentSearchKeyword
-        recentKeywords={recentSearchKeyword}
-        onSearchKeyword={handleSearch}
-        onRemoveKeyword={handleRemoveKeyword}
-      />
+      {viewType === "RESULT" ? (
+        <SearchResults results={searchResults} isLoading={isSearching} />
+      ) : (
+        <RecentSearchKeyword
+          recentKeywords={recentSearchKeyword}
+          onSearchKeyword={handleSearch}
+          onRemoveKeyword={handleRemoveKeyword}
+        />
+      )}
     </div>
   );
 };

--- a/src/features/search-schedule/ui/index.tsx
+++ b/src/features/search-schedule/ui/index.tsx
@@ -1,9 +1,12 @@
 import { Button, Input } from "@/shared/ui";
 import { Search } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { RecentSearchKeyword } from "./RecentSearchKeyword";
 import { SearchResults } from "./SearchResults";
-import { RecentSearchKeyword } from "./recentSearchKeyword";
 import type { SearchResultItem, ViewType } from "./types";
+
+const MAX_RECENT_KEYWORD_NUM = 5;
+const RECENT_SEARCH_KEYWORD_STORAGE_KEY = "recentSearchKeyword";
 
 /**
  * 검색을 위한 사이드바 컴포넌트입니다.
@@ -22,53 +25,53 @@ export const SearchSchedule = () => {
       setIsSearching(true);
 
       const filtered = recentSearchKeyword.filter((keyword) => keyword !== query);
-      const updated = [query, ...filtered].slice(0, 5);
+      const updated = [query, ...filtered].slice(0, MAX_RECENT_KEYWORD_NUM);
       setRecentSearchKeyword(updated);
 
-      localStorage.setItem("recentSearchKeyword", updated.join(","));
+      localStorage.setItem(RECENT_SEARCH_KEYWORD_STORAGE_KEY, updated.join(","));
 
       if (keyword && searchInputRef.current) {
         searchInputRef.current.value = keyword;
       }
-    }
 
-    // TODO: 검색 API 호출
-    setTimeout(() => {
-      setSearchResults([
-        {
-          scheduleId: 12,
-          calendarId: 5,
-          calendarName: "팀 프로젝트",
-          title: "팀 회의",
-          startDate: "2025-04-01",
-          endDate: "2025-04-01",
-          startTime: "09:00",
-          endTime: "10:00",
-        },
-        {
-          scheduleId: 27,
-          calendarId: 3,
-          calendarName: "개인 캘린더",
-          title: "고객 회의",
-          startDate: "2025-04-01",
-          endDate: "2025-04-01",
-          startTime: "15:00",
-          endTime: "16:00",
-        },
-      ]);
-      setIsSearching(false);
-      setViewType("RESULT");
-    }, 500);
+      // TODO: 검색 API 호출
+      setTimeout(() => {
+        setSearchResults([
+          {
+            scheduleId: 12,
+            calendarId: 5,
+            calendarName: "팀 프로젝트",
+            title: "팀 회의",
+            startDate: "2025-04-01",
+            endDate: "2025-04-01",
+            startTime: "09:00",
+            endTime: "10:00",
+          },
+          {
+            scheduleId: 27,
+            calendarId: 3,
+            calendarName: "개인 캘린더",
+            title: "고객 회의",
+            startDate: "2025-04-01",
+            endDate: "2025-04-01",
+            startTime: "15:00",
+            endTime: "16:00",
+          },
+        ]);
+        setIsSearching(false);
+        setViewType("RESULT");
+      }, 500);
+    }
   };
 
   const handleRemoveKeyword = (removeKeyword: string) => {
     const updated = recentSearchKeyword.filter((val) => val !== removeKeyword);
     setRecentSearchKeyword(updated);
-    localStorage.setItem("recentSearchKeyword", updated.join(","));
+    localStorage.setItem(RECENT_SEARCH_KEYWORD_STORAGE_KEY, updated.join(","));
   };
 
   useEffect(() => {
-    const savedKeywords = localStorage.getItem("recentSearchKeyword");
+    const savedKeywords = localStorage.getItem(RECENT_SEARCH_KEYWORD_STORAGE_KEY);
     if (savedKeywords) {
       const keywords = savedKeywords.split(",").filter((keyword) => keyword.trim() !== "");
       setRecentSearchKeyword(keywords);

--- a/src/features/search-schedule/ui/index.tsx
+++ b/src/features/search-schedule/ui/index.tsx
@@ -1,0 +1,93 @@
+import { Button, Input } from "@/shared/ui";
+import { Search, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * 검색을 위한 사이드바 컴포넌트입니다.
+ * 검색어 입력 기능을 제공합니다.
+ */
+export const SearchSchedule = () => {
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const [recentSearchKeyword, setRecentSearchKeyword] = useState<string[]>([]);
+
+  const handleSearch = () => {
+    const query = searchInputRef.current?.value.trim() || "";
+    if (query) {
+      const filtered = recentSearchKeyword.filter((keyword) => keyword !== query);
+      const updated = [query, ...filtered].slice(0, 5);
+      setRecentSearchKeyword(updated);
+
+      localStorage.setItem("recentSearchKeyword", updated.join(","));
+    }
+  };
+
+  const handleRemoveKeyword = (indexToRemove: number) => {
+    setRecentSearchKeyword((prev) => {
+      const updated = prev.filter((_, index) => index !== indexToRemove);
+      localStorage.setItem("recentSearchKeyword", updated.join(","));
+      return updated;
+    });
+  };
+
+  useEffect(() => {
+    const savedKeywords = localStorage.getItem("recentSearchKeyword");
+    if (savedKeywords) {
+      const keywords = savedKeywords.split(",").filter((keyword) => keyword.trim() !== "");
+      setRecentSearchKeyword(keywords);
+    }
+  }, []);
+
+  return (
+    <div className="flex h-full flex-col p-2">
+      <div className="mb-4 flex items-center gap-1">
+        <Input
+          type="text"
+          ref={searchInputRef}
+          placeholder="검색어를 입력하세요"
+          className="w-full rounded-lg border border-grayscale-400 p-2 outline-none focus:border-transparent focus:ring-2 focus:ring-primary-main"
+          onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+        />
+        <Button type="button" variant="ghost" size="icon" onClick={handleSearch} className="group hover:bg-transparent">
+          <Search className="size-6 text-grayscale-400 transition-colors group-hover:text-primary-main" />
+        </Button>
+      </div>
+
+      {/* 최근 검색어 */}
+      {recentSearchKeyword.length > 0 && (
+        <div className="space-y-2">
+          <h3 className="font-medium text-grayscale-700 text-sm">최근 검색어</h3>
+          <ul className="space-y-1">
+            {recentSearchKeyword.map((keyword, index) => (
+              <li key={`${index}-${keyword}`} className="group">
+                <div className="flex items-center justify-between rounded-md p-2 transition-colors hover:bg-grayscale-50">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      if (searchInputRef.current) {
+                        searchInputRef.current.value = keyword;
+                        handleSearch();
+                      }
+                    }}
+                    className="min-w-0 flex-1 text-left text-grayscale-600 text-sm transition-colors hover:text-grayscale-900"
+                  >
+                    <span className="block truncate">{keyword}</span>
+                  </button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => handleRemoveKeyword(index)}
+                    className="h-6 w-6 flex-shrink-0 hover:bg-grayscale-100"
+                    aria-label={`"${keyword}" 검색 기록 삭제`}
+                  >
+                    <X className="size-3 text-grayscale-400" />
+                  </Button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/features/search-schedule/ui/types.ts
+++ b/src/features/search-schedule/ui/types.ts
@@ -1,0 +1,12 @@
+export interface SearchResultItem {
+  scheduleId: number;
+  calendarId: number;
+  calendarName: string;
+  title: string;
+  startDate: string;
+  endDate: string;
+  startTime: string;
+  endTime: string;
+}
+
+export type ViewType = "RECENT" | "RESULT";

--- a/src/widgets/RightSidebar/index.tsx
+++ b/src/widgets/RightSidebar/index.tsx
@@ -1,4 +1,5 @@
 import { CreateSchedule, EditSchedule } from "@/features/input-schedule";
+import { SearchSchedule } from "@/features/search-schedule";
 import { ShareSchedule } from "@/features/share-schedule";
 import { DailySchedule } from "@/features/view-daily-schedule";
 import type { RightSidebarViewType } from "@/shared/model";
@@ -28,7 +29,7 @@ export const RightSidebar = () => {
       case "edit":
         return <EditSchedule onCancel={() => setCurrentView("daily")} />;
       case "search":
-        return <div>일정 검색</div>;
+        return <SearchSchedule />;
       case "notification":
         return <div>알림</div>;
       default:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #17 

## 📋 작업 요약

|![image](https://github.com/user-attachments/assets/adedf37e-0871-45d1-ba27-1efbb9e75399)|![image](https://github.com/user-attachments/assets/1eefe06e-1281-45c7-b8bd-19057da56514)|![image](https://github.com/user-attachments/assets/aafb399a-0a01-4dee-aeb2-bf3031be5fcd)|
|--|--|--|
|최근 검색어(기본 보기)|검색 결과|검색 결과가 0개일 때|

## 🔍 세부 내용

### 검색 UI 구현

- 검색 Input 및 최근 검색어 기능 (localStorage 사용, 최대 5개) 구현
- 검색 결과 표시 컴포넌트 구현
- viewType 상태를 이용하여 UI 상태 관리(최근 검색어를 보여줄지, 검색 결과를 보여줄지)
