### PR TITLE
[Feat] 설정 UI 구현

### DIFF
--- a/src/features/manage-settings/index.ts
+++ b/src/features/manage-settings/index.ts
@@ -1,0 +1,1 @@
+export { ManageSettings } from "./ui";

--- a/src/features/manage-settings/ui/EditProfile.tsx
+++ b/src/features/manage-settings/ui/EditProfile.tsx
@@ -1,0 +1,75 @@
+import { Button, Input } from "@/shared/ui";
+import { Label } from "@/shared/ui/label";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+
+interface ProfileFormData {
+  nickname: string;
+}
+
+export const EditProfile = () => {
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    formState: { errors, isSubmitting },
+  } = useForm<ProfileFormData>();
+
+  useEffect(() => {
+    const fetchProfile = async () => {
+      // TODO: 프로필 조회 API 호출
+      // const profile = await getUserProfile();
+      // setValue("nickname", profile.nickname);
+
+      // 임시 데이터
+      setValue("nickname", "홍길동");
+    };
+
+    fetchProfile();
+  }, [setValue]);
+
+  const onSubmit = async (data: ProfileFormData) => {
+    // TODO: 프로필 업데이트 API 호출
+    console.log(`${data.nickname} 변경 완료!`);
+  };
+
+  return (
+    <section className="flex h-full w-full flex-col">
+      <div className="flex h-16 items-center justify-between p-4">
+        <h3 className="text-bold-l text-grayscale-black">프로필 편집</h3>
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="flex flex-1 flex-col p-3">
+        <div className="flex-1 space-y-6">
+          <div className="relative space-y-2">
+            <Label htmlFor="nickname" className="font-medium text-gray-700 text-sm">
+              닉네임
+            </Label>
+            <Input
+              id="nickname"
+              {...register("nickname", {
+                required: "닉네임을 입력해주세요",
+              })}
+              placeholder="닉네임을 입력하세요"
+              className="w-full"
+            />
+            {errors.nickname && (
+              <p className="-top-0 absolute right-0 text-medium-s text-notification-strong">
+                {errors.nickname.message}
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-2 p-2">
+          <Button type="submit" disabled={isSubmitting} className="w-20">
+            {isSubmitting ? "저장 중..." : "저장"}
+          </Button>
+          <Button type="button" variant="outline" className="w-20">
+            취소
+          </Button>
+        </div>
+      </form>
+    </section>
+  );
+};

--- a/src/features/manage-settings/ui/Inquiry.tsx
+++ b/src/features/manage-settings/ui/Inquiry.tsx
@@ -1,0 +1,107 @@
+import { Button, Input, Textarea } from "@/shared/ui";
+import { Label } from "@/shared/ui/label";
+import { useForm } from "react-hook-form";
+
+interface InquiryFormData {
+  title: string;
+  email: string;
+  content: string;
+}
+
+export const Inquiry = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    reset,
+  } = useForm<InquiryFormData>();
+
+  const onSubmit = async (data: InquiryFormData) => {
+    try {
+      // TODO: 문의하기 API 호출
+      console.log("문의 전송:", data);
+      // await submitInquiry(data);
+      reset();
+      // TODO: 문의 접수 성공 토스트
+    } catch (error) {
+      console.error("문의 전송 실패:", error);
+    }
+  };
+
+  const handleCancel = () => {
+    reset();
+  };
+
+  return (
+    <section className="flex h-full w-full flex-col">
+      <div className="flex h-16 items-center justify-between p-4">
+        <h3 className="text-bold-l text-grayscale-black">1:1 문의/건의하기</h3>
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="flex flex-1 flex-col p-3">
+        <div className="flex-1 space-y-3">
+          <div className="space-y-2">
+            <Label htmlFor="title" className="text-grayscale-700 text-medium-l">
+              제목
+            </Label>
+            <Input
+              id="title"
+              {...register("title", {
+                required: "제목을 입력해주세요",
+                maxLength: {
+                  value: 100,
+                  message: "제목은 최대 100글자까지 입력 가능합니다",
+                },
+              })}
+              placeholder="문의 제목을 입력하세요"
+              className="w-full"
+            />
+            {errors.title && <p className="text-medium-s text-notification-strong">{errors.title.message}</p>}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="email" className="text-grayscale-700 text-medium-l">
+              이메일
+            </Label>
+            <Input
+              id="email"
+              type="email"
+              {...register("email", {
+                required: "이메일을 입력해주세요",
+                pattern: {
+                  value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+                  message: "올바른 이메일 형식을 입력해주세요",
+                },
+              })}
+              placeholder="답변 받을 이메일을 입력하세요"
+              className="w-full"
+            />
+            {errors.email && <p className="text-medium-s text-notification-strong">{errors.email.message}</p>}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="content" className="text-grayscale-700 text-medium-l">
+              내용
+            </Label>
+            <Textarea
+              id="content"
+              {...register("content", {
+                required: "문의 내용을 입력해주세요",
+              })}
+              placeholder="문의하실 내용을 자세히 입력해주세요"
+              className="min-h-32 w-full resize-none"
+              rows={8}
+            />
+            {errors.content && <p className="text-medium-s text-notification-strong">{errors.content.message}</p>}
+          </div>
+        </div>
+
+        <div className="flex justify-end">
+          <Button type="submit" disabled={isSubmitting} className="w-20">
+            {isSubmitting ? "전송 중..." : "확인"}
+          </Button>
+        </div>
+      </form>
+    </section>
+  );
+};

--- a/src/features/manage-settings/ui/TermsOfUse.tsx
+++ b/src/features/manage-settings/ui/TermsOfUse.tsx
@@ -1,0 +1,11 @@
+export const TermsOfUse = () => {
+  return (
+    <section className="flex h-full w-full flex-col">
+      <div className="flex h-16 items-center justify-between p-4">
+        <h3 className="text-bold-l text-grayscale-black">사용 약관</h3>
+      </div>
+
+      <div className="p-3 text-grayscale-700 text-medium-s">어쩌구 저쩌구</div>
+    </section>
+  );
+};

--- a/src/features/manage-settings/ui/index.tsx
+++ b/src/features/manage-settings/ui/index.tsx
@@ -1,0 +1,63 @@
+import { Button, Dialog, DialogContent, DialogTrigger } from "@/shared/ui";
+import { ChevronRight, Settings } from "lucide-react";
+import { useState } from "react";
+import { EditProfile } from "./EditProfile";
+import { Inquiry } from "./Inquiry";
+import { TermsOfUse } from "./TermsOfUse";
+
+type ViewType = "EDIT_PROFILE" | "TERMS_OF_USE" | "INQUIRY";
+
+const VIEW_TYPE = [
+  { label: "프로필 편집", value: "EDIT_PROFILE" as ViewType },
+  { label: "사용 약관", value: "TERMS_OF_USE" as ViewType },
+  { label: "1:1 문의/건의하기", value: "INQUIRY" as ViewType },
+];
+
+export const ManageSettings = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [view, setView] = useState<ViewType>("EDIT_PROFILE");
+
+  const renderView = () => {
+    switch (view) {
+      case "EDIT_PROFILE":
+        return <EditProfile />;
+      case "TERMS_OF_USE":
+        return <TermsOfUse />;
+      case "INQUIRY":
+        return <Inquiry />;
+    }
+  };
+  return (
+    <div className="flex">
+      <Dialog open={isOpen} onOpenChange={setIsOpen}>
+        <DialogTrigger asChild>
+          <Settings size={18} className="text-grayscale-700" />
+        </DialogTrigger>
+        <DialogContent className="flex h-1/2 w-1/2 gap-0 rounded-lg p-0">
+          <div className="h-full w-48 rounded-l-lg bg-grayscale-100 px-1">
+            <header className="flex h-20 w-full items-center justify-start px-2">
+              <h2 className="text-bold-l text-grayscale-black">설정</h2>
+            </header>
+            <div className="flex flex-col items-start space-y-1">
+              {VIEW_TYPE.map((val) => {
+                return (
+                  <Button
+                    key={val.value}
+                    variant="ghost"
+                    className="flex w-full justify-between"
+                    onClick={() => setView(val.value)}
+                  >
+                    <span>{val.label}</span>
+                    <ChevronRight />
+                  </Button>
+                );
+              })}
+            </div>
+          </div>
+
+          {renderView()}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};

--- a/src/features/manage-settings/ui/index.tsx
+++ b/src/features/manage-settings/ui/index.tsx
@@ -44,10 +44,10 @@ export const ManageSettings = () => {
                   <Button
                     key={val.value}
                     variant="ghost"
-                    className="flex w-full justify-between text-grayscale-700 text-medium-s"
+                    className="flex w-full justify-between"
                     onClick={() => setView(val.value)}
                   >
-                    <span>{val.label}</span>
+                    <span className="text-grayscale-700 text-medium-s">{val.label}</span>
                     <ChevronRight />
                   </Button>
                 );

--- a/src/features/manage-settings/ui/index.tsx
+++ b/src/features/manage-settings/ui/index.tsx
@@ -44,7 +44,7 @@ export const ManageSettings = () => {
                   <Button
                     key={val.value}
                     variant="ghost"
-                    className="flex w-full justify-between"
+                    className="flex w-full justify-between text-grayscale-700 text-medium-s"
                     onClick={() => setView(val.value)}
                   >
                     <span>{val.label}</span>

--- a/src/widgets/LeftSidebar/ui/UserInfo.tsx
+++ b/src/widgets/LeftSidebar/ui/UserInfo.tsx
@@ -1,20 +1,13 @@
-import { Button } from "@/shared/ui";
-import { Settings } from "lucide-react";
+import { ManageSettings } from "@/features/manage-settings";
 
 export const UserInfo = () => {
-  const handleOpenSetting = () => {
-    console.log("설정창 오픈");
-  };
-
   return (
     <div className="flex items-center justify-between p-4">
       <div className="flex flex-col items-start justify-center gap-2">
         <span className="font-medium text-bold-m text-grayscale-700">홍길동</span>
         <span className="text-grayscale-700 text-medium-s">abcd@gmail.com</span>
       </div>
-      <Button size="icon" variant="ghost" onClick={handleOpenSetting}>
-        <Settings size={18} className="text-grayscale-700" />
-      </Button>
+      <ManageSettings />
     </div>
   );
 };


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #19 

## 📋 작업 요약

|![image](https://github.com/user-attachments/assets/b8710e74-c63f-4b91-9de4-b94d88612652)|![image](https://github.com/user-attachments/assets/dc3f3acc-6ea1-4028-84ac-37364566a16f)|![image](https://github.com/user-attachments/assets/9db4bbce-6acf-4580-a724-338c99654b08)|
|--|--|--|
|프로필 편집|사용 약관|1:1 문의/건의하기|

## 🔍 세부 내용

:exclamation: 저번에 캘린더 생성/편집 UI의 Dialog 크기가 너무 크다는 피드백이 있었기에 해당 Dialog의 크기도 Figma에 그려놓은 것보다 작게 조정해서 구현함.

### 설정 Dialog 구현

- shadcn/ui의 Dialog를 이용한 설정창 구현
- 왼쪽 사이드 바를 이용하여 "프로필 편집", "사용 약관', "1:1 문의/건의하기"로 이동 가능
- 기본 보기는 "프로필 편집"

### 프로필 편집

- 닉네임 수정 UI 제공
- react hook form 사용

### 1:1 문의/건의하기

- 이름, 이메일, 내용 작성하여 문의 가능
- react hook form 사용

## 🤔 논의가 필요한 점

- 사용 약관: 내용은 어떤 것을 사용할지
- 1:1 문의/건의하기: 이메일은 회원 기본 정보에 포함되어 있는데, 보내야 하는지?
