### PR TITLE
[Feat] 알림 UI 구현

### DIFF
--- a/src/entities/notification/index.ts
+++ b/src/entities/notification/index.ts
@@ -1,0 +1,1 @@
+export * from "./model";

--- a/src/entities/notification/model/index.ts
+++ b/src/entities/notification/model/index.ts
@@ -1,0 +1,1 @@
+export type { Notification } from "./types";

--- a/src/entities/notification/model/index.ts
+++ b/src/entities/notification/model/index.ts
@@ -1,1 +1,1 @@
-export type { Notification } from "./types";
+export type { Notification, NotificationType } from "./types";

--- a/src/entities/notification/model/types.ts
+++ b/src/entities/notification/model/types.ts
@@ -1,0 +1,10 @@
+export type NotificationType = "CALENDAR_INVITATION" | "CALENDAR_INVITATION_ACCEPT" | "SCHEDULE_REMINDER";
+
+export interface Notification {
+  id: number;
+  type: NotificationType;
+  title: string;
+  data: Record<string, unknown>;
+  isRead: boolean;
+  createdAt: string;
+}

--- a/src/features/notification/consts/index.ts
+++ b/src/features/notification/consts/index.ts
@@ -1,0 +1,7 @@
+import type { NotificationType } from "@/entities/notification";
+
+export const NOTIFICATION_TYPE_LABELS: Record<NotificationType, string> = {
+  CALENDAR_INVITATION: "캘린더 초대",
+  CALENDAR_INVITATION_ACCEPT: "초대 수락",
+  SCHEDULE_REMINDER: "일정 알림",
+} as const;

--- a/src/features/notification/index.ts
+++ b/src/features/notification/index.ts
@@ -1,0 +1,1 @@
+export * from "./ui";

--- a/src/features/notification/lib/index.ts
+++ b/src/features/notification/lib/index.ts
@@ -1,0 +1,20 @@
+export const getRelativeTime = (createdAt: string): string => {
+  const now = new Date();
+  const createdTime = new Date(createdAt);
+  const diffInMs = now.getTime() - createdTime.getTime();
+
+  const diffInMinutes = Math.floor(diffInMs / (1000 * 60));
+  const diffInHours = Math.floor(diffInMs / (1000 * 60 * 60));
+  const diffInDays = Math.floor(diffInMs / (1000 * 60 * 60 * 24));
+
+  if (diffInMinutes < 1) {
+    return "방금 전";
+  }
+  if (diffInMinutes < 60) {
+    return `${diffInMinutes}분 전`;
+  }
+  if (diffInHours < 24) {
+    return `${diffInHours}시간 전`;
+  }
+  return `${diffInDays}일 전`;
+};

--- a/src/features/notification/ui/NotificationItem.tsx
+++ b/src/features/notification/ui/NotificationItem.tsx
@@ -1,0 +1,45 @@
+import type { Notification } from "@/entities/notification";
+import { X } from "lucide-react";
+import { NOTIFICATION_TYPE_LABELS } from "../consts";
+import { getRelativeTime } from "../lib";
+
+interface NotificationItemProps {
+  notification: Notification;
+}
+
+export const NotificationItem = ({ notification }: NotificationItemProps) => {
+  const handleClick = (e: React.MouseEvent) => {
+    const target = e.target as HTMLElement;
+
+    if (target.closest('[data-action="delete"]')) {
+      e.stopPropagation();
+      console.log("알림 삭제");
+      return;
+    }
+
+    console.log("알림 확인");
+  };
+
+  return (
+    <button
+      type="button"
+      className="flex w-full cursor-pointer flex-col gap-2 rounded-lg border p-3 text-left transition-colors hover:bg-grayscale-100 hover:shadow-sm"
+      onClick={handleClick}
+    >
+      <div className="flex items-center justify-between">
+        <span className="text-bold-m text-grayscale-black">{NOTIFICATION_TYPE_LABELS[notification.type]} 알림</span>
+        <div className="flex items-center">
+          <span className="text-grayscale-500 text-medium-s">{getRelativeTime(notification.createdAt)}</span>
+          <span
+            data-action="delete"
+            className="inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded text-grayscale-500 hover:text-grayscale-black"
+            aria-label="알림 삭제"
+          >
+            <X className="h-4 w-4" />
+          </span>
+        </div>
+      </div>
+      <p className="text-grayscale-700 text-medium-s">{notification.title}</p>
+    </button>
+  );
+};

--- a/src/features/notification/ui/index.tsx
+++ b/src/features/notification/ui/index.tsx
@@ -40,7 +40,7 @@ export const NotificationList = () => {
       <div className="flex h-20 items-center gap-2 p-6">
         <h2 className="text-bold-l text-grayscale-black">알림</h2>
         {unreadCount > 0 && (
-          <Badge variant="destructive" className="!text-grayscale-white rounded-[99px] px-2 text-medium-s">
+          <Badge variant="destructive" className="rounded-[99px] px-2 text-grayscale-white text-medium-s">
             {unreadCount}
           </Badge>
         )}

--- a/src/features/notification/ui/index.tsx
+++ b/src/features/notification/ui/index.tsx
@@ -1,0 +1,56 @@
+import type { Notification } from "@/entities/notification";
+import { Badge } from "@/shared/ui/badge";
+import { useEffect, useState } from "react";
+import { NotificationItem } from "./NotificationItem";
+
+/**
+ * 우측 사이드바에서 사용되는 알림 컴포넌트입니다.
+ * 일정 알림, 캘린더 초대 알림 등을 표시하고 읽음 처리 및 삭제 기능을 제공합니다.
+ */
+export const NotificationList = () => {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const unreadCount = notifications.filter((item) => !item.isRead).length;
+
+  useEffect(() => {
+    // TODO: 알림 조회 API 호출
+    setNotifications([
+      {
+        id: 123,
+        type: "CALENDAR_INVITATION",
+        title: "뼝뼝 님이 뿅뿅 캘린더에 초대했습니다.",
+        data: {
+          calendarId: 3,
+        },
+        isRead: false,
+        createdAt: "2025-04-29T08:00:00Z",
+      },
+      {
+        id: 124,
+        type: "CALENDAR_INVITATION_ACCEPT",
+        title: "뿅뿅님이 뿅뿅캘린더 초대를 수락했습니다",
+        data: {},
+        isRead: false,
+        createdAt: "2025-04-28T12:30:00Z",
+      },
+    ]);
+  }, []);
+
+  return (
+    <div className="w-full max-w-sm p-3">
+      <div className="flex h-20 items-center gap-2 p-6">
+        <h2 className="text-bold-l text-grayscale-black">알림</h2>
+        {unreadCount > 0 && (
+          <Badge variant="destructive" className="!text-grayscale-white rounded-[99px] px-2 text-medium-s">
+            {unreadCount}
+          </Badge>
+        )}
+      </div>
+
+      <div className="space-y-3">
+        {notifications.map((notification) => (
+          <NotificationItem key={notification.id} notification={notification} />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/features/notification/ui/index.tsx
+++ b/src/features/notification/ui/index.tsx
@@ -40,7 +40,7 @@ export const NotificationList = () => {
       <div className="flex h-20 items-center gap-2 p-6">
         <h2 className="text-bold-l text-grayscale-black">알림</h2>
         {unreadCount > 0 && (
-          <Badge variant="destructive" className="rounded-[99px] px-2 text-grayscale-white text-medium-s">
+          <Badge variant="destructive" className="rounded-[99px] px-2 text-medium-s">
             {unreadCount}
           </Badge>
         )}

--- a/src/shared/lib/utils.ts
+++ b/src/shared/lib/utils.ts
@@ -1,6 +1,109 @@
 import { type ClassValue, clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { extendTailwindMerge } from "tailwind-merge";
+
+const customTwMerge = extendTailwindMerge({
+  extend: {
+    classGroups: {
+      // 텍스트 색상
+      "text-color": [
+        // grayscale
+        "text-grayscale-white",
+        "text-grayscale-100",
+        "text-grayscale-200",
+        "text-grayscale-300",
+        "text-grayscale-400",
+        "text-grayscale-500",
+        "text-grayscale-700",
+        "text-grayscale-black",
+
+        // primary (blue)
+        "text-primary-main",
+        "text-primary-light",
+        "text-primary-dark",
+
+        // notification (red)
+        "text-notification-strong",
+        "text-notification-medium",
+        "text-notification-light",
+
+        // category colors
+        "text-category-red",
+        "text-category-orange",
+        "text-category-amber",
+        "text-category-green",
+        "text-category-teal",
+        "text-category-cyan",
+        "text-category-purple",
+        "text-category-pink",
+        "text-category-gray",
+      ],
+
+      // 배경 색상
+      "bg-color": [
+        // grayscale
+        "bg-grayscale-white",
+        "bg-grayscale-100",
+        "bg-grayscale-200",
+        "bg-grayscale-300",
+        "bg-grayscale-400",
+        "bg-grayscale-500",
+        "bg-grayscale-700",
+        "bg-grayscale-black",
+
+        // primary (blue)
+        "bg-primary-main",
+        "bg-primary-light",
+        "bg-primary-dark",
+
+        // notification (red)
+        "bg-notification-strong",
+        "bg-notification-medium",
+        "bg-notification-light",
+
+        // category colors
+        "bg-category-red",
+        "bg-category-orange",
+        "bg-category-amber",
+        "bg-category-green",
+        "bg-category-teal",
+        "bg-category-cyan",
+        "bg-category-purple",
+        "bg-category-pink",
+        "bg-category-gray",
+      ],
+
+      // 경계선 색상
+      "border-color": [
+        "border-grayscale-white",
+        "border-grayscale-100",
+        "border-grayscale-200",
+        "border-grayscale-300",
+        "border-grayscale-400",
+        "border-grayscale-500",
+        "border-grayscale-700",
+        "border-grayscale-black",
+        "border-primary-main",
+        "border-primary-light",
+        "border-primary-dark",
+        "border-notification-strong",
+        "border-notification-medium",
+        "border-notification-light",
+      ],
+
+      // 커스텀 타이포그래피
+      "font-size": [
+        "text-bold-l",
+        "text-bold-m",
+        "text-bold-r",
+        "text-bold-s",
+        "text-medium-m",
+        "text-medium-r",
+        "text-medium-s",
+      ],
+    },
+  },
+});
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
+  return customTwMerge(clsx(inputs));
 }

--- a/src/shared/ui/badge.tsx
+++ b/src/shared/ui/badge.tsx
@@ -12,7 +12,7 @@ const badgeVariants = cva(
         default: "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
         secondary: "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
         destructive:
-          "border-transparent bg-destructive text-white focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90",
+          "border-transparent bg-notification-strong text-grayscal-white focus-visible:ring-notification-strong/20 dark:bg-notification-strong/60 dark:focus-visible:ring-notification-strong/40 [a&]:hover:bg-notification-strong/90",
         outline: "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
       },
     },

--- a/src/shared/ui/badge.tsx
+++ b/src/shared/ui/badge.tsx
@@ -12,7 +12,7 @@ const badgeVariants = cva(
         default: "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
         secondary: "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
         destructive:
-          "border-transparent bg-notification-strong text-grayscal-white focus-visible:ring-notification-strong/20 dark:bg-notification-strong/60 dark:focus-visible:ring-notification-strong/40 [a&]:hover:bg-notification-strong/90",
+          "border-transparent bg-notification-strong text-grayscale-white focus-visible:ring-notification-strong/20 dark:bg-notification-strong/60 dark:focus-visible:ring-notification-strong/40 [a&]:hover:bg-notification-strong/90",
         outline: "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
       },
     },

--- a/src/widgets/RightSidebar/index.tsx
+++ b/src/widgets/RightSidebar/index.tsx
@@ -1,4 +1,5 @@
 import { CreateSchedule, EditSchedule } from "@/features/input-schedule";
+import { NotificationList } from "@/features/notification";
 import { SearchSchedule } from "@/features/search-schedule";
 import { ShareSchedule } from "@/features/share-schedule";
 import { DailySchedule } from "@/features/view-daily-schedule";
@@ -31,7 +32,7 @@ export const RightSidebar = () => {
       case "search":
         return <SearchSchedule />;
       case "notification":
-        return <div>알림</div>;
+        return <NotificationList />;
       default:
         return <DailySchedule onSetView={setCurrentView} />;
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #18 

## 📋 작업 요약

![image](https://github.com/user-attachments/assets/1ae12257-4214-4f72-af31-d7ef5f0c0113)

## 🔍 세부 내용

### entities 레이어에 notification 슬라이스 생성

- 타입 정의 (`Notification`, `NotificationType` 등)

### features 레이어에 notification 기능 구현

- NotificationList: 알림 목록 컨테이너 컴포넌트

  - Badge를 이용하여 읽지 않은 알림 개수 표시
  - 알림 목록 렌더링 및 상태 관리
 
- NotificationItem: 개별 알림 아이템 컴포넌트

  - 상대 시간 표시 ("3분 전", "2시간 전" 등)
  - 알림 확인/삭제 기능

## 🤔 구현하며 있었던 문제 & 해결

### 1️⃣ 접근성을 고려한 중첩 버튼 문제 해결

#### 문제

![image](https://github.com/user-attachments/assets/5dda54ca-3883-4a36-b1a8-3a4c98578c43)

이 알림 아이템도 클릭 시 동작이 있기 때문에  웹 접근성을 고려하면 `<button>` 요소로 구현하는 것이 적절하다. 그런데 이 알림 아이템 안의 X 버튼도 별도의 삭제 동작을 가진 버튼이다.

여기서 문제는 `<button>` 안에 `<button>`을 중첩하는 것이 HTML 표준에 위반된다는 점이다. MDN 문서에 따르면 버튼 요소 내부에는 [Interactive content](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Content_categories#interactive_content)가 올 수 없다.

####  해결

이를 해결하기 위해 이벤트 위임 방식을 선택했다. 이벤트 위임 방식을 사용하면 다음과 같은 형태로 구현이 된다.

```typescript
export const NotificationItem = ({ notification }: NotificationItemProps) => {
  const handleClick = (e: React.MouseEvent) => {
  const target = e.target as HTMLElement;
  
  if (target.closest('[data-action="delete"]')) {
    e.stopPropagation();
    console.log("알림 삭제");
    return;
  }
  
  console.log("알림 확인");
  };
  
  // ...

  return (
    <button
      type="button"
      onClick={handleClick}
    >
      <div>
        <span>{NOTIFICATION_TYPE_LABELS[notification.type]} 알림</span>
        <div>
          <span>{getRelativeTime(notification.createdAt)}</span>
          <span
            data-action="delete"
            aria-label="알림 삭제"
          >
            <X className="h-4 w-4" />
          </span>
        </div>
      </div>
      <p>{notification.title}</p>
    </button>
  );
};
```

-  상위 요소인 알림 아이템 전체에만 `<button>` 태그를 적용하고, X 버튼은 `<span>`으로 변경하여 data-action="delete" 속성을 지정했다.
- 알림 아이템 전체 wrapper의 클릭 이벤트 핸들러에서 하위 요소의 data-action 속성을 확인하여 적절한 동작을 수행하도록 구현했다.

#### 🔗 참고 자료

- [\<button>: The Button element (MDN)](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#technical_summary)
- [html의 data-속성 사용법 완벽 가이드](https://inpa.tistory.com/entry/JS-%F0%9F%93%9A-HTML-%EB%8D%B0%EC%9D%B4%ED%84%B0%EC%85%8Bdata-%EC%86%8D%EC%84%B1)

### 2️⃣ Badge 컴포넌트의 텍스트 색상 문제

#### 문제

shadcn/ui에서 갖고 온 Badge 컴포넌트에서 뱃지 안에 나타나는 텍스트의 색상이 지정해둔 white가 아니라 검은색으로 나타나는 현상이 있었다.

#### 원인 파악 

개발자 도구 확인 결과, Badge 컴포넌트에서 지정한 text-grayscale-white 클래스가 아예 로드되지 않고 있었다. 대신 index.css의 전역 스타일인 text-foreground가 적용되고 있었다.

```css
/* index.css */

@layer base {
  * {
    @apply border-border outline-ring/50;
  }
  body {
    @apply bg-background text-foreground;
  }
}
```

이리 저리 원인을 찾다보니 같은 문제를 마주한 사람들의 글을 찾을 수 있었고, 여기서 내 문제의 진짜 원인을 파악할 수 있었다.

원인은 `cn` 함수에서 사용하는 tailwind-merge가 커스텀 색상 클래스를 인식하지 못해 해당 클래스를 제거하고 있었던 것이었다. tailwind-merge는 Tailwind의 기본 클래스만 알고 있어서 `@theme`에서 정의한 커스텀 클래스들을 "알 수 없는 클래스"로 판단하여 제거한다.

#### 해결

`tailwind-merge`에서 제공하는 `extendTailwindMerge` 함수를 `twMerge` 대신 사용해주는 것으로 해결했다. 이때, `extendTailwindMerge`가 인식할 수 있도록 index.css에서 정의해둔 커스텀 클래스들을 `classGroups`에 등록했다.

```typescript
const customTwMerge = extendTailwindMerge({
  extend: {
    classGroups: {
      "text-color": ["text-grayscale-white", "text-primary-main", ...],
      "bg-color": ["bg-notification-strong", "bg-primary-main", ...],
      "border-color": ["border-grayscale-200", ...],
      "font-size": ["text-bold-l", "text-medium-s", ...]
    }
  }
});

export function cn(...inputs: ClassValue[]) {
  return customTwMerge(clsx(inputs));
}
```

#### 참고 자료

- [tailwind merge 커스텀 클래스 오버라이딩 문제 해결](https://xionwcfm.tistory.com/419)
- [tailwind-merge Github (extendTailwindMerge)](https://github.com/dcastil/tailwind-merge/blob/v3.3.1/docs/api-reference.md#extendtailwindmerge)

## ❗ 개선이 필요한 점

- 사이드 바 컴포넌트들이 뒤로 돌아갈 수 있는 버튼이 필요할 것 같음. 이는 알림뿐만 아니라 다른 컴포넌트들에도 공통적으로 필요한 요소라 생각하여 별도의 이슈로 만들어서 구현 예정