### PR TITLE
[Feat] Member API 구현 및 연결

### DIFF
--- a/src/entities/member/api/index.ts
+++ b/src/entities/member/api/index.ts
@@ -1,0 +1,1 @@
+export * from "./memberApi";

--- a/src/entities/member/api/memberApi.ts
+++ b/src/entities/member/api/memberApi.ts
@@ -1,5 +1,11 @@
+import { axiosInstance } from "@/shared/api";
+import type { Member } from "../model";
+
 export const memberApi = {
-  getMyProfile: async () => {},
+  getMyProfile: async (): Promise<Member> => {
+    const result = await axiosInstance.get("/members/me");
+    return result.data.data;
+  },
   editMyProfile: async () => {},
   withdrawMyAccount: async () => {},
 

--- a/src/entities/member/api/memberApi.ts
+++ b/src/entities/member/api/memberApi.ts
@@ -6,7 +6,10 @@ export const memberApi = {
     const result = await axiosInstance.get("/members/me");
     return result.data.data;
   },
-  editMyProfile: async () => {},
+  editMyProfile: async (newData: Partial<Member>) => {
+    const result = await axiosInstance.patch("/members/me", newData);
+    return result.data.data;
+  },
   withdrawMyAccount: async () => {},
 
   searchMembers: async () => {},

--- a/src/entities/member/api/memberApi.ts
+++ b/src/entities/member/api/memberApi.ts
@@ -1,0 +1,7 @@
+export const memberApi = {
+  getMyProfile: async () => {},
+  editMyProfile: async () => {},
+  withdrawMyAccount: async () => {},
+
+  searchMembers: async () => {},
+};

--- a/src/entities/member/api/memberApi.ts
+++ b/src/entities/member/api/memberApi.ts
@@ -12,5 +12,8 @@ export const memberApi = {
   },
   withdrawMyAccount: async () => {},
 
-  searchMembers: async () => {},
+  searchMember: async (email: string) => {
+    const result = await axiosInstance.get("/members/search", { params: { email } });
+    return result.data.data;
+  },
 };

--- a/src/entities/member/api/memberApi.ts
+++ b/src/entities/member/api/memberApi.ts
@@ -6,13 +6,13 @@ export const memberApi = {
     const result = await axiosInstance.get("/members/me");
     return result.data.data;
   },
-  editMyProfile: async (newData: Partial<Member>) => {
+  editMyProfile: async (newData: Partial<Member>): Promise<{ nickname: string }> => {
     const result = await axiosInstance.patch("/members/me", newData);
     return result.data.data;
   },
   withdrawMyAccount: async () => {},
 
-  searchMember: async (email: string) => {
+  searchMember: async (email: string): Promise<Member[]> => {
     const result = await axiosInstance.get("/members/search", { params: { email } });
     return result.data.data;
   },

--- a/src/entities/member/model/types.ts
+++ b/src/entities/member/model/types.ts
@@ -2,4 +2,7 @@ export interface Member {
   id: number;
   email: string;
   nickname: string;
+  socialType?: "KAKAO" | "GOOGLE";
+  createdAt?: string;
+  updatedAt?: string;
 }

--- a/src/features/create-calendar/ui/index.tsx
+++ b/src/features/create-calendar/ui/index.tsx
@@ -1,9 +1,10 @@
 import { cn, devLogger } from "@/shared/lib";
 import { Plus, Trash2 } from "lucide-react";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
 
 import type { CalendarParticipant, CalendarRole, ScheduleCalendar } from "@/entities/calendar";
+import type { Member } from "@/entities/member/model";
 import { ROLE_OPTIONS } from "@/shared/const";
 import {
   Button,
@@ -19,6 +20,7 @@ import {
   FormItem,
   FormLabel,
   Input,
+  MemberSearchInput,
   ScrollArea,
   Select,
   SelectContent,
@@ -31,12 +33,11 @@ type CreateCalendarFormData = Omit<ScheduleCalendar, "id">;
 
 /**
  * 새로운 캘린더를 생성하는 다이얼로그 컴포넌트입니다.
- * 캘린더 이름을 설정하고, 참가자들을 추가하여 생성합니다.
+ * 캘린더 이름을 설정하고, 참가자들을 검색하여 추가한 후 생성합니다.
  */
 export const CreateCalendar = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
-  const emailInputRef = useRef<HTMLInputElement>(null);
 
   const form = useForm<CreateCalendarFormData>({
     defaultValues: {
@@ -50,35 +51,18 @@ export const CreateCalendar = () => {
     name: "participants",
   });
 
-  const handleInvite = () => {
-    const emailInput = emailInputRef.current?.value.trim();
-    if (!emailInput) return;
-
-    // TODO: 검색 결과 나온 유저만 추가하도록 변경
-    const emails = emailInput
-      .split(",")
-      .map((email) => email.trim())
-      .filter(Boolean);
-
+  const handleSelectMember = (member: Member) => {
     const existingEmails = fields.map((field) => field.email);
 
-    const newParticipants = emails
-      .filter((email) => email && !existingEmails.includes(email))
-      .map(
-        (email): CalendarParticipant => ({
-          id: Date.now() + Math.random(),
-          email,
-          nickname: email,
-          role: "VIEWER",
-        }),
-      );
+    if (!existingEmails.includes(member.email)) {
+      const newParticipant: CalendarParticipant = {
+        id: member.id,
+        email: member.email,
+        nickname: member.nickname,
+        role: "VIEWER",
+      };
 
-    for (const participant of newParticipants) {
-      append(participant);
-    }
-
-    if (emailInputRef.current) {
-      emailInputRef.current.value = "";
+      append(newParticipant);
     }
   };
 
@@ -94,11 +78,7 @@ export const CreateCalendar = () => {
   const handleSubmit = async (data: CreateCalendarFormData) => {
     setIsSubmitting(true);
     try {
-      // TODO: 캘린더 생성 API 호출
       form.reset();
-      if (emailInputRef.current) {
-        emailInputRef.current.value = "";
-      }
       devLogger.log("캘린더 생성:", data);
       setIsOpen(false);
     } catch (error) {
@@ -110,9 +90,6 @@ export const CreateCalendar = () => {
 
   const handleCancel = () => {
     form.reset();
-    if (emailInputRef.current) {
-      emailInputRef.current.value = "";
-    }
     setIsOpen(false);
   };
 
@@ -120,9 +97,6 @@ export const CreateCalendar = () => {
     setIsOpen(open);
     if (open) {
       form.reset();
-      if (emailInputRef.current) {
-        emailInputRef.current.value = "";
-      }
     }
   };
 
@@ -164,22 +138,10 @@ export const CreateCalendar = () => {
             <div className="flex min-h-0 flex-1 flex-col space-y-4">
               <FormLabel>멤버</FormLabel>
 
-              <div className="flex gap-2">
-                <Input
-                  ref={emailInputRef}
-                  placeholder="이메일을 입력하세요"
-                  className="flex-1"
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") {
-                      e.preventDefault();
-                      handleInvite();
-                    }
-                  }}
-                />
-                <Button type="button" onClick={handleInvite}>
-                  Invite
-                </Button>
-              </div>
+              <MemberSearchInput
+                excludeEmails={fields.map((field) => field.email)}
+                onSelectMember={handleSelectMember}
+              />
 
               {fields.length > 0 && (
                 <ScrollArea className="max-h-80 w-full rounded-lg border border-grayscale-400 p-3">

--- a/src/features/edit-calendar/ui/index.tsx
+++ b/src/features/edit-calendar/ui/index.tsx
@@ -137,8 +137,9 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
 
     setIsInviting(true);
     try {
-      // TODO: 여러 멤버 일괄 초대 API 호출
+      // TODO: 여러 멤버 초대 API 호출
 
+      // API 성공 후에만 UI 업데이트
       const newParticipants: CalendarParticipant[] = selectedMembers.map((member) => ({
         id: member.id,
         email: member.email,
@@ -153,6 +154,7 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
     } catch (error) {
       console.error("참가자 초대 실패:", error);
       // TODO: 에러 토스트 표시
+      // UI 상태는 자동으로 원래대로 유지됨 (API 실패 시 아무것도 변경하지 않음)
     } finally {
       setIsInviting(false);
     }

--- a/src/features/edit-calendar/ui/index.tsx
+++ b/src/features/edit-calendar/ui/index.tsx
@@ -56,7 +56,7 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
   const [participants, setParticipants] = useState<CalendarParticipant[]>([]);
   const [showDeleteCalendar, setShowDeleteCalendar] = useState(false);
   const [showDeleteMember, setShowDeleteMember] = useState(false);
-  const [selectedMember, setSelectedMember] = useState<Member | null>(null);
+  const [selectedMembers, setSelectedMembers] = useState<Member[]>([]);
 
   const form = useForm<EditCalendarFormData>({
     defaultValues: {
@@ -67,9 +67,9 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
 
   const excludeEmails = useMemo(() => {
     const participantEmails = participants.map((p) => p.email);
-    const selectedEmail = selectedMember ? [selectedMember.email] : [];
-    return [...participantEmails, ...selectedEmail];
-  }, [participants, selectedMember]);
+    const selectedEmails = selectedMembers.map((m) => m.email);
+    return [...participantEmails, ...selectedEmails];
+  }, [participants, selectedMembers]);
 
   const fetchCalendarData = useCallback(async (id: number): Promise<EditableScheduleCalendar> => {
     try {
@@ -125,22 +125,29 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
   }, [calendarId, isOpen, fetchCalendarData, form]);
 
   const handleSelectMember = (member: Member) => {
-    setSelectedMember(member);
+    setSelectedMembers((prev) => [...prev, member]);
   };
 
-  const handleInvite = async () => {
-    if (!selectedMember) return;
+  const handleRemoveSelectedMember = (memberId: number) => {
+    setSelectedMembers((prev) => prev.filter((m) => m.id !== memberId));
+  };
+
+  const handleInviteAll = async () => {
+    if (selectedMembers.length === 0) return;
 
     setIsInviting(true);
     try {
-      const newParticipant: CalendarParticipant = {
-        id: selectedMember.id,
-        email: selectedMember.email,
-        nickname: selectedMember.nickname,
+      // TODO: 여러 멤버 일괄 초대 API 호출
+
+      const newParticipants: CalendarParticipant[] = selectedMembers.map((member) => ({
+        id: member.id,
+        email: member.email,
+        nickname: member.nickname,
         role: "VIEWER",
-      };
-      setParticipants((prev) => [...prev, newParticipant]);
-      setSelectedMember(null);
+      }));
+
+      setParticipants((prev) => [...prev, ...newParticipants]);
+      setSelectedMembers([]);
 
       // TODO: 성공 토스트 표시
     } catch (error) {
@@ -298,29 +305,39 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
                     onSelectMember={handleSelectMember}
                     className="flex-1"
                   />
-                  <Button type="button" onClick={handleInvite} disabled={isInviting || !selectedMember}>
-                    {isInviting ? "초대 중..." : "초대"}
+                  <Button type="button" onClick={handleInviteAll} disabled={isInviting || selectedMembers.length === 0}>
+                    {isInviting ? "초대 중..." : `초대 (${selectedMembers.length})`}
                   </Button>
                 </div>
 
-                {selectedMember && (
-                  <div className="flex items-center gap-2 rounded-lg border border-primary-main/20 bg-primary-main/5 p-3">
-                    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-grayscale-100">
-                      <User className="h-4 w-4 text-grayscale-600" />
+                {selectedMembers.length > 0 && (
+                  <div className="space-y-2">
+                    <div className="text-grayscale-600 text-small">선택된 멤버 ({selectedMembers.length}명)</div>
+                    <div className="max-h-40 space-y-2 overflow-y-auto">
+                      {selectedMembers.map((member) => (
+                        <div
+                          key={member.id}
+                          className="flex items-center gap-2 rounded-lg border border-primary-main/20 bg-primary-main/5 p-3"
+                        >
+                          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-grayscale-100">
+                            <User className="h-4 w-4 text-grayscale-600" />
+                          </div>
+                          <div className="min-w-0 flex-1">
+                            <div className="truncate text-grayscale-700 text-medium-r">{member.nickname}</div>
+                            <div className="truncate text-grayscale-400 text-medium-s">{member.email}</div>
+                          </div>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => handleRemoveSelectedMember(member.id)}
+                            className="text-grayscale-400"
+                          >
+                            <X className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      ))}
                     </div>
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate text-grayscale-700 text-medium-r">{selectedMember.nickname}</div>
-                      <div className="truncate text-grayscale-400 text-medium-s">{selectedMember.email}</div>
-                    </div>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => setSelectedMember(null)}
-                      className="text-grayscale-400"
-                    >
-                      <X className="h-4 w-4" />
-                    </Button>
                   </div>
                 )}
 

--- a/src/features/edit-calendar/ui/index.tsx
+++ b/src/features/edit-calendar/ui/index.tsx
@@ -1,4 +1,5 @@
 import type { CalendarParticipant, CalendarRole, ScheduleCalendar } from "@/entities/calendar";
+import type { Member } from "@/entities/member/model";
 import { ROLE_OPTIONS } from "@/shared/const";
 import { cn } from "@/shared/lib";
 import {
@@ -16,6 +17,7 @@ import {
   FormItem,
   FormLabel,
   Input,
+  MemberSearchInput,
   ScrollArea,
   Select,
   SelectContent,
@@ -24,8 +26,8 @@ import {
   SelectValue,
   TextConfirmDialog,
 } from "@/shared/ui";
-import { PenSquare, Trash2 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { PenSquare, Trash2, User, X } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 
 interface EditableScheduleCalendar extends ScheduleCalendar {
@@ -51,10 +53,10 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isInviting, setIsInviting] = useState(false);
   const [error, setError] = useState<string | undefined>(undefined);
-  const emailInputRef = useRef<HTMLInputElement>(null);
   const [participants, setParticipants] = useState<CalendarParticipant[]>([]);
   const [showDeleteCalendar, setShowDeleteCalendar] = useState(false);
   const [showDeleteMember, setShowDeleteMember] = useState(false);
+  const [selectedMember, setSelectedMember] = useState<Member | null>(null);
 
   const form = useForm<EditCalendarFormData>({
     defaultValues: {
@@ -62,6 +64,12 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
       nickname: "",
     },
   });
+
+  const excludeEmails = useMemo(() => {
+    const participantEmails = participants.map((p) => p.email);
+    const selectedEmail = selectedMember ? [selectedMember.email] : [];
+    return [...participantEmails, ...selectedEmail];
+  }, [participants, selectedMember]);
 
   const fetchCalendarData = useCallback(async (id: number): Promise<EditableScheduleCalendar> => {
     try {
@@ -106,10 +114,6 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
           nickname: data.nickname || "",
         });
         setParticipants(data.participants || []);
-
-        if (emailInputRef.current) {
-          emailInputRef.current.value = "";
-        }
       } catch (err) {
         setError(err instanceof Error ? err.message : "알 수 없는 오류가 발생했습니다.");
       } finally {
@@ -120,27 +124,23 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
     loadCalendarData();
   }, [calendarId, isOpen, fetchCalendarData, form]);
 
-  // TODO: 이메일로 사용자 검색 미리보기 API(디바운싱) 호출 함수
+  const handleSelectMember = (member: Member) => {
+    setSelectedMember(member);
+  };
 
   const handleInvite = async () => {
-    const emailInput = emailInputRef.current?.value.trim();
-    if (!emailInput) return;
+    if (!selectedMember) return;
 
     setIsInviting(true);
     try {
-      // TODO: 초대 API 호출
-
       const newParticipant: CalendarParticipant = {
-        id: Date.now(),
-        email: emailInput,
-        nickname: emailInput,
+        id: selectedMember.id,
+        email: selectedMember.email,
+        nickname: selectedMember.nickname,
         role: "VIEWER",
       };
       setParticipants((prev) => [...prev, newParticipant]);
-
-      if (emailInputRef.current) {
-        emailInputRef.current.value = "";
-      }
+      setSelectedMember(null);
 
       // TODO: 성공 토스트 표시
     } catch (error) {
@@ -198,9 +198,6 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
 
   const handleCancel = () => {
     form.reset();
-    if (emailInputRef.current) {
-      emailInputRef.current.value = "";
-    }
     setIsOpen(false);
   };
 
@@ -220,7 +217,6 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
     setIsOpen(open);
     if (open) {
       form.reset();
-      if (emailInputRef.current) emailInputRef.current.value = "";
     }
   };
 
@@ -296,21 +292,37 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
                 <FormLabel>멤버</FormLabel>
 
                 <div className="flex gap-2">
-                  <Input
-                    ref={emailInputRef}
-                    placeholder="이메일을 입력하세요"
+                  <MemberSearchInput
+                    placeholder="이메일 또는 닉네임을 입력하여 멤버를 검색하세요"
+                    excludeEmails={excludeEmails}
+                    onSelectMember={handleSelectMember}
                     className="flex-1"
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") {
-                        e.preventDefault();
-                        handleInvite();
-                      }
-                    }}
                   />
-                  <Button type="button" onClick={handleInvite} disabled={isInviting}>
-                    {isInviting ? "초대 중..." : "Invite"}
+                  <Button type="button" onClick={handleInvite} disabled={isInviting || !selectedMember}>
+                    {isInviting ? "초대 중..." : "초대"}
                   </Button>
                 </div>
+
+                {selectedMember && (
+                  <div className="flex items-center gap-2 rounded-lg border border-primary-main/20 bg-primary-main/5 p-3">
+                    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-grayscale-100">
+                      <User className="h-4 w-4 text-grayscale-600" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-grayscale-700 text-medium-r">{selectedMember.nickname}</div>
+                      <div className="truncate text-grayscale-400 text-medium-s">{selectedMember.email}</div>
+                    </div>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setSelectedMember(null)}
+                      className="text-grayscale-400"
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  </div>
+                )}
 
                 {participants.length > 0 && (
                   <ScrollArea className="max-h-80 rounded-lg border border-grayscale-400 p-3">

--- a/src/features/manage-settings/ui/EditProfile.tsx
+++ b/src/features/manage-settings/ui/EditProfile.tsx
@@ -1,13 +1,20 @@
+import { useAuthStore } from "@/shared/stores";
 import { Button, Input } from "@/shared/ui";
 import { Label } from "@/shared/ui/label";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 
+interface EditProfileProps {
+  onCancel: () => void;
+}
+
 interface ProfileFormData {
   nickname: string;
 }
 
-export const EditProfile = () => {
+export const EditProfile = ({ onCancel }: EditProfileProps) => {
+  const user = useAuthStore((state) => state.user);
+
   const {
     register,
     handleSubmit,
@@ -16,17 +23,10 @@ export const EditProfile = () => {
   } = useForm<ProfileFormData>();
 
   useEffect(() => {
-    const fetchProfile = async () => {
-      // TODO: 프로필 조회 API 호출
-      // const profile = await getUserProfile();
-      // setValue("nickname", profile.nickname);
-
-      // 임시 데이터
-      setValue("nickname", "홍길동");
-    };
-
-    fetchProfile();
-  }, [setValue]);
+    if (user) {
+      setValue("nickname", user.nickname);
+    }
+  }, [setValue, user]);
 
   const onSubmit = async (data: ProfileFormData) => {
     // TODO: 프로필 업데이트 API 호출
@@ -65,7 +65,7 @@ export const EditProfile = () => {
           <Button type="submit" disabled={isSubmitting} className="w-20">
             {isSubmitting ? "저장 중..." : "저장"}
           </Button>
-          <Button type="button" variant="outline" className="w-20">
+          <Button type="button" variant="outline" className="w-20" onClick={onCancel}>
             취소
           </Button>
         </div>

--- a/src/features/manage-settings/ui/EditProfile.tsx
+++ b/src/features/manage-settings/ui/EditProfile.tsx
@@ -1,9 +1,11 @@
 import { memberApi } from "@/entities/member/api";
+import { devLogger } from "@/shared/lib";
 import { useAuthStore } from "@/shared/stores";
 import { Button, Input } from "@/shared/ui";
 import { Label } from "@/shared/ui/label";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
+import { toast } from "sonner";
 import { useShallow } from "zustand/shallow";
 
 interface EditProfileProps {
@@ -35,8 +37,10 @@ export const EditProfile = ({ onCancel }: EditProfileProps) => {
       const result = await memberApi.editMyProfile(data);
       updateUser({ nickname: result.nickname });
       onCancel();
+      toast.success("프로필이 성공적으로 수정되었습니다.");
     } catch (error) {
-      console.error("프로필 수정 실패:", error);
+      devLogger.error("프로필 수정 실패:", error);
+      toast.error("프로필 수정에 실패했습니다. 다시 시도해주세요.");
     }
   };
 

--- a/src/features/manage-settings/ui/EditProfile.tsx
+++ b/src/features/manage-settings/ui/EditProfile.tsx
@@ -1,8 +1,10 @@
+import { memberApi } from "@/entities/member/api";
 import { useAuthStore } from "@/shared/stores";
 import { Button, Input } from "@/shared/ui";
 import { Label } from "@/shared/ui/label";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
+import { useShallow } from "zustand/shallow";
 
 interface EditProfileProps {
   onCancel: () => void;
@@ -13,7 +15,7 @@ interface ProfileFormData {
 }
 
 export const EditProfile = ({ onCancel }: EditProfileProps) => {
-  const user = useAuthStore((state) => state.user);
+  const [user, updateUser] = useAuthStore(useShallow((state) => [state.user, state.updateUser]));
 
   const {
     register,
@@ -23,14 +25,19 @@ export const EditProfile = ({ onCancel }: EditProfileProps) => {
   } = useForm<ProfileFormData>();
 
   useEffect(() => {
-    if (user) {
+    if (user?.nickname) {
       setValue("nickname", user.nickname);
     }
-  }, [setValue, user]);
+  }, [user?.nickname, setValue]);
 
   const onSubmit = async (data: ProfileFormData) => {
-    // TODO: 프로필 업데이트 API 호출
-    console.log(`${data.nickname} 변경 완료!`);
+    try {
+      const result = await memberApi.editMyProfile(data);
+      updateUser({ nickname: result.nickname });
+      onCancel();
+    } catch (error) {
+      console.error("프로필 수정 실패:", error);
+    }
   };
 
   return (

--- a/src/features/manage-settings/ui/index.tsx
+++ b/src/features/manage-settings/ui/index.tsx
@@ -23,7 +23,7 @@ export const ManageSettings = () => {
   const renderView = () => {
     switch (view) {
       case "EDIT_PROFILE":
-        return <EditProfile />;
+        return <EditProfile onCancel={() => setIsOpen(false)} />;
       case "TERMS_OF_USE":
         return <TermsOfUse />;
       case "INQUIRY":

--- a/src/pages/oauth-redirect/ui/index.tsx
+++ b/src/pages/oauth-redirect/ui/index.tsx
@@ -1,3 +1,5 @@
+import { memberApi } from "@/entities/member/api";
+import { devLogger } from "@/shared/lib";
 import { useAuthStore } from "@/shared/stores";
 import { useEffect } from "react";
 import { useNavigate, useSearchParams } from "react-router";
@@ -5,25 +7,44 @@ import { toast } from "sonner";
 
 /**
  * 소셜 로그인 리다이렉션을 처리하는 페이지입니다.
- * URL 파라미터에서 토큰을 추출하여 스토어에 저장합니다.
+ * URL 파라미터에서 토큰을 추출하여 스토어에 저장하고,
+ * 사용자 정보를 조회하여 함께 저장합니다.
  */
 export const OAuthRedirectPage = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const setAuth = useAuthStore((state) => state.setAuth);
+  const { setAuth, setUser } = useAuthStore((state) => ({
+    setAuth: state.setAuth,
+    setUser: state.setUser,
+  }));
 
   useEffect(() => {
-    const accessToken = searchParams.get("accessToken");
-    const refreshToken = searchParams.get("refreshToken");
+    const processOAuthCallback = async () => {
+      try {
+        const accessToken = searchParams.get("accessToken");
+        const refreshToken = searchParams.get("refreshToken");
 
-    if (accessToken && refreshToken) {
-      setAuth(accessToken, refreshToken);
-      navigate("/", { replace: true });
-    } else {
-      toast.error("소셜 로그인 실패");
-      navigate("/login", { replace: true });
-    }
-  }, [searchParams, setAuth, navigate]);
+        if (!accessToken || !refreshToken) {
+          toast.error("소셜 로그인 실패");
+          navigate("/login", { replace: true });
+          return;
+        }
+
+        setAuth(accessToken, refreshToken);
+
+        const user = await memberApi.getMyProfile();
+        setUser(user);
+
+        navigate("/", { replace: true });
+      } catch (error) {
+        devLogger.error("OAuth 콜백 처리 실패:", error);
+        toast.error("로그인 처리 중 오류가 발생했습니다.");
+        navigate("/login", { replace: true });
+      }
+    };
+
+    processOAuthCallback();
+  }, [searchParams, setAuth, setUser, navigate]);
 
   return (
     <div className="flex min-h-screen items-center justify-center">

--- a/src/shared/stores/authStore.ts
+++ b/src/shared/stores/authStore.ts
@@ -1,3 +1,4 @@
+import type { Member } from "@/entities/member";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
@@ -6,10 +7,13 @@ const STORAGE_KEY = "scheduo-auth";
 interface AuthState {
   accessToken: string | null;
   refreshToken: string | null;
+  user: Member | null;
 
-  setAuth: (accessToken: string, refreshToken: string) => void;
+  setAuth: (accessToken: string, refreshToken: string, user?: Member) => void;
   clearAuth: () => void;
   updateAccessToken: (accessToken: string) => void;
+  setUser: (user: Member) => void;
+  updateUser: (updates: Partial<Member>) => void;
 }
 
 export const useAuthStore = create<AuthState>()(
@@ -17,20 +21,30 @@ export const useAuthStore = create<AuthState>()(
     (set) => ({
       accessToken: null,
       refreshToken: null,
+      user: null,
 
-      setAuth: (accessToken, refreshToken) =>
+      setAuth: (accessToken, refreshToken, user) =>
         set({
           accessToken,
           refreshToken,
+          user,
         }),
 
       clearAuth: () =>
         set({
           accessToken: null,
           refreshToken: null,
+          user: null,
         }),
 
       updateAccessToken: (accessToken) => set({ accessToken }),
+
+      setUser: (user) => set({ user }),
+
+      updateUser: (updates) =>
+        set((state) => ({
+          user: state.user ? { ...state.user, ...updates } : null,
+        })),
     }),
     {
       name: STORAGE_KEY,

--- a/src/shared/stores/authStore.ts
+++ b/src/shared/stores/authStore.ts
@@ -24,11 +24,11 @@ export const useAuthStore = create<AuthState>()(
       user: null,
 
       setAuth: (accessToken, refreshToken, user) =>
-        set({
+        set((state) => ({
           accessToken,
           refreshToken,
-          user,
-        }),
+          user: user ?? state.user,
+        })),
 
       clearAuth: () =>
         set({

--- a/src/shared/ui/MemberSearchInput.tsx
+++ b/src/shared/ui/MemberSearchInput.tsx
@@ -1,0 +1,150 @@
+import { cn, devLogger } from "@/shared/lib";
+import { Loader2, User } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import { memberApi } from "@/entities/member/api";
+import type { Member } from "@/entities/member/model";
+import { Input } from "@/shared/ui";
+
+interface MemberSearchInputProps {
+  placeholder?: string;
+  excludeEmails?: string[];
+  onSelectMember: (member: Member) => void;
+  className?: string;
+}
+
+interface SearchResult {
+  users: Member[];
+}
+
+/**
+ * 멤버를 검색하고 선택할 수 있는 검색 입력 컴포넌트입니다.
+ * 실시간 검색과 드롭다운 결과를 제공합니다.
+ */
+export const MemberSearchInput = ({
+  placeholder = "이메일을 입력하여 멤버를 검색하세요",
+  excludeEmails = [],
+  onSelectMember,
+  className,
+}: MemberSearchInputProps) => {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<Member[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [showSearchResults, setShowSearchResults] = useState(false);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const searchContainerRef = useRef<HTMLDivElement>(null);
+
+  // 검색 디바운싱을 위한 useEffect
+  useEffect(() => {
+    const timeoutId = setTimeout(async () => {
+      if (searchQuery.trim().length >= 2) {
+        setIsSearching(true);
+        try {
+          const result: SearchResult = await memberApi.searchMember(searchQuery.trim());
+          setSearchResults(result.users || []);
+          setShowSearchResults(true);
+        } catch (error) {
+          devLogger.error("멤버 검색 실패:", error);
+          setSearchResults([]);
+        } finally {
+          setIsSearching(false);
+        }
+      } else {
+        setSearchResults([]);
+        setShowSearchResults(false);
+      }
+    }, 300);
+
+    return () => clearTimeout(timeoutId);
+  }, [searchQuery]);
+
+  // 검색 결과 영역 외부 클릭 시 닫기
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (searchContainerRef.current && !searchContainerRef.current.contains(event.target as Node)) {
+        setShowSearchResults(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const handleSearchInputChange = (value: string) => {
+    setSearchQuery(value);
+  };
+
+  const handleSelectMember = (member: Member) => {
+    onSelectMember(member);
+
+    // 검색 초기화
+    setSearchQuery("");
+    setSearchResults([]);
+    setShowSearchResults(false);
+    inputRef.current?.focus();
+  };
+
+  return (
+    <div className={cn("relative", className)} ref={searchContainerRef}>
+      <div className="relative">
+        <Input
+          ref={inputRef}
+          placeholder={placeholder}
+          value={searchQuery}
+          onChange={(e) => handleSearchInputChange(e.target.value)}
+          onFocus={() => {
+            if (searchResults.length > 0) {
+              setShowSearchResults(true);
+            }
+          }}
+        />
+        {isSearching && (
+          <div className="-translate-y-1/2 absolute top-1/2 right-3">
+            <Loader2 className="h-4 w-4 animate-spin text-grayscale-400" />
+          </div>
+        )}
+      </div>
+
+      {/* 검색 결과 드롭다운 */}
+      {showSearchResults && searchResults.length > 0 && (
+        <div className="absolute top-full z-50 mt-1 max-h-60 w-full overflow-auto rounded-lg border border-grayscale-300 bg-white shadow-lg">
+          {searchResults.map((member) => {
+            const isExcluded = excludeEmails.includes(member.email);
+
+            return (
+              <button
+                key={member.id}
+                type="button"
+                onClick={() => !isExcluded && handleSelectMember(member)}
+                disabled={isExcluded}
+                className={cn(
+                  "flex w-full items-center gap-3 px-4 py-3 text-left transition-colors",
+                  isExcluded
+                    ? "cursor-not-allowed bg-grayscale-50 text-grayscale-400"
+                    : "cursor-pointer hover:bg-grayscale-50",
+                )}
+              >
+                <div className="flex h-8 w-8 items-center justify-center rounded-full bg-grayscale-100">
+                  <User className="h-4 w-4 text-grayscale-600" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-grayscale-700 text-medium-r">{member.nickname}</div>
+                  <div className="truncate text-grayscale-400 text-medium-s">{member.email}</div>
+                </div>
+                {isExcluded && <span className="text-grayscale-400 text-small">이미 추가됨</span>}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* 검색 결과가 없는 경우 */}
+      {showSearchResults && searchResults.length === 0 && searchQuery.trim().length >= 2 && !isSearching && (
+        <div className="absolute top-full z-50 mt-1 w-full rounded-lg border border-grayscale-300 bg-white p-4 text-center text-grayscale-400 text-medium-r shadow-lg">
+          검색 결과가 없습니다
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -15,3 +15,4 @@ export { ConfirmDialog } from "./ConfirmDialog";
 export { Google } from "./icons/Google";
 export { Kakao } from "./icons/Kakao";
 export * from "./sonner";
+export { MemberSearchInput } from "./MemberSearchInput";

--- a/src/widgets/LeftSidebar/ui/UserInfo.tsx
+++ b/src/widgets/LeftSidebar/ui/UserInfo.tsx
@@ -1,11 +1,18 @@
 import { ManageSettings } from "@/features/manage-settings";
+import { useAuthStore } from "@/shared/stores";
 
 export const UserInfo = () => {
+  const user = useAuthStore((state) => state.user);
+
+  if (!user) {
+    return <div>사용자 정보를 불러올 수 없습니다.</div>;
+  }
+
   return (
     <div className="flex items-center justify-between p-4">
       <div className="flex flex-col items-start justify-center gap-2">
-        <span className="font-medium text-bold-m text-grayscale-700">홍길동</span>
-        <span className="text-grayscale-700 text-medium-s">abcd@gmail.com</span>
+        <span className="font-medium text-bold-m text-grayscale-700">{user.nickname}</span>
+        <span className="text-grayscale-700 text-medium-s">{user.email}</span>
       </div>
       <ManageSettings />
     </div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #40 

## 📋 작업 요약
### 구현 및 연결 완료된 API
- 프로필 조회 (`getMyProfile`)
- 프로필 편집 (`editMyProfile`) 
- 멤버 검색 (`searchMembers`)

## 🔍 세부 내용

### 1️⃣ Zustand를 이용한 유저 정보 관리
- 기존 authStore에 유저 정보 추가
- OAuth 리다이렉트 후 사용자 정보 자동 저장
- `useShallow`를 활용한 불필요한 리렌더링 방지

### 2️⃣ 멤버 검색 기능 및 UI 개선
- **검색 API 연결**: 디바운싱(300ms)을 이용한 검색 API 호출 최적화
- **검색 결과 드롭다운 UI**: 실시간 검색 결과 표시 및 선택 기능
    
    ![image](https://github.com/user-attachments/assets/1b8b5665-307c-4ae7-9250-fcd33d1d811a)

- **공통 컴포넌트화**: `MemberSearchInput`을 `shared/ui`로 분리하여 재사용성 향상
- **중복 방지**: 이미 추가된 멤버 자동 제외 기능

### 3️⃣ EditCalendar UX 개선
- 여러 명을 검색해서 선택 목록에 추가
- 선택된 멤버들을 카드 형태로 시각적 표시
- 일괄 초대 기능으로 사용자 편의성 향상

## 😮 미구현 사항

- 회원 탈퇴: 백엔드 측에서도 해당 API가 아직 구현되지 않은 것 같아서 이 부분은 아직 구현하지 않았습니다.