### PR TITLE
[Fix] memberApi.searchMember 반환 타입 수정

### DIFF
--- a/src/entities/member/api/memberApi.ts
+++ b/src/entities/member/api/memberApi.ts
@@ -12,7 +12,7 @@ export const memberApi = {
   },
   withdrawMyAccount: async () => {},
 
-  searchMember: async (email: string): Promise<Member[]> => {
+  searchMember: async (email: string): Promise<{ users: Member[] }> => {
     const result = await axiosInstance.get("/members/search", { params: { email } });
     return result.data.data;
   },


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #53 

## 🚨 문제

- 기능은 정상 작동하지만 TypeScript 빌드 에러 발생: `Property 'users' is missing in type 'Member[]'`
- 이로 인해 Vercel 배포 실패

## 🔍 해결 방법

- `src/entities/member/api/memberApi.ts`: `searchMember` 함수 반환 타입 수정
  - API 반환 타입을 `Member[]`에서 `{users: Member[]}` 형태로 수정
  - 실제 서버 응답 구조와 일치하도록 타입 정의 변경
