### PR TITLE
[Feat] 캘린더 API 연결

### DIFF
--- a/src/entities/calendar/api/calendarApi.ts
+++ b/src/entities/calendar/api/calendarApi.ts
@@ -2,6 +2,7 @@ import { axiosInstance } from "@/shared/api";
 import type {
   CreateCalendarRequest,
   CreateCalendarResponse,
+  GetCalendarByIdResponse,
   GetCalendarListResponse,
   InviteToCalendarRequest,
   UpdateCalendarRequest,
@@ -28,7 +29,7 @@ export const calendarApi = {
     return result.data.data;
   },
 
-  getCalendarById: async (calendarId: number) => {
+  getCalendarById: async (calendarId: number): Promise<GetCalendarByIdResponse> => {
     const result = await axiosInstance.get(`/calendars/${calendarId}`);
     return result.data.data;
   },

--- a/src/entities/calendar/api/calendarApi.ts
+++ b/src/entities/calendar/api/calendarApi.ts
@@ -28,6 +28,10 @@ export const calendarApi = {
     return result.data.data;
   },
 
+  getCalendarById: async (calendarId: number) => {
+    return { id: calendarId, title: "수정 전 이름", participants: [], nickname: "수정 전 닉네임" };
+  },
+
   acceptInvite: async (calendarId: number) => {
     await axiosInstance.post(`/calendars/${calendarId}/invite/accept`);
   },

--- a/src/entities/calendar/api/calendarApi.ts
+++ b/src/entities/calendar/api/calendarApi.ts
@@ -29,7 +29,8 @@ export const calendarApi = {
   },
 
   getCalendarById: async (calendarId: number) => {
-    return { id: calendarId, title: "수정 전 이름", participants: [], nickname: "수정 전 닉네임" };
+    const result = await axiosInstance.get(`/calendars/${calendarId}`);
+    return result.data.data;
   },
 
   acceptInvite: async (calendarId: number) => {

--- a/src/entities/calendar/api/calendarApi.ts
+++ b/src/entities/calendar/api/calendarApi.ts
@@ -1,12 +1,37 @@
+import { axiosInstance } from "@/shared/api";
+import type {
+  CreateCalendarRequest,
+  CreateCalendarResponse,
+  GetCalendarListResponse,
+  InviteToCalendarRequest,
+  UpdateCalendarRequest,
+} from "./types";
+
 export const calendarApi = {
-  createCalendar: async () => {},
-  updateCalendar: async () => {},
-  deleteCalendar: async () => {},
+  createCalendar: async (data: CreateCalendarRequest): Promise<CreateCalendarResponse> => {
+    const result = await axiosInstance.post("/calendars", data);
+    return result.data.data;
+  },
+  updateCalendar: async (calendarId: number, data: UpdateCalendarRequest) => {
+    await axiosInstance.patch(`/calendars/${calendarId}`, data);
+  },
+  deleteCalendar: async (calendarId: number) => {
+    await axiosInstance.delete(`/calendars/${calendarId}`);
+  },
 
-  inviteToCalendar: async () => {},
+  inviteToCalendar: async (calendarId: number, data: InviteToCalendarRequest) => {
+    await axiosInstance.post(`/calendars/${calendarId}`, data);
+  },
 
-  getCalendarList: async () => {},
+  getCalendarList: async (): Promise<GetCalendarListResponse> => {
+    const result = await axiosInstance.get("/calendars");
+    return result.data.data;
+  },
 
-  acceptInvite: async () => {},
-  rejectInvite: async () => {},
+  acceptInvite: async (calendarId: number) => {
+    await axiosInstance.post(`/calendars/${calendarId}/invite/accept`);
+  },
+  rejectInvite: async (calendarId: number) => {
+    await axiosInstance.post(`/calendars/${calendarId}/invite/decline`);
+  },
 };

--- a/src/entities/calendar/api/participantApi.ts
+++ b/src/entities/calendar/api/participantApi.ts
@@ -1,4 +1,11 @@
+import { axiosInstance } from "@/shared/api";
+import type { CalendarRole } from "../model";
+
 export const participantApi = {
-  modifyRole: async () => {},
-  deleteParticipant: async () => {},
+  modifyRole: async (calendarId: number, participantId: number, role: CalendarRole) => {
+    await axiosInstance.patch(`/calendars/${calendarId}/participants/${participantId}`, { data: { role } });
+  },
+  deleteParticipant: async (calendarId: number, participantId: number) => {
+    await axiosInstance.delete(`/calendars/${calendarId}/participants/${participantId}`);
+  },
 };

--- a/src/entities/calendar/api/participantApi.ts
+++ b/src/entities/calendar/api/participantApi.ts
@@ -3,7 +3,7 @@ import type { CalendarRole } from "../model";
 
 export const participantApi = {
   modifyRole: async (calendarId: number, participantId: number, role: CalendarRole) => {
-    await axiosInstance.patch(`/calendars/${calendarId}/participants/${participantId}`, { data: { role } });
+    await axiosInstance.patch(`/calendars/${calendarId}/participants/${participantId}`, { role });
   },
   deleteParticipant: async (calendarId: number, participantId: number) => {
     await axiosInstance.delete(`/calendars/${calendarId}/participants/${participantId}`);

--- a/src/entities/calendar/api/types.ts
+++ b/src/entities/calendar/api/types.ts
@@ -1,8 +1,8 @@
-import type { CalendarInfo, CalendarParticipant } from "../model";
+import type { CalendarInfo, CalendarParticipant, CalendarRole } from "../model";
 
 export interface CreateCalendarRequest {
   title: string;
-  participants: CalendarParticipant[];
+  participants: Pick<CalendarParticipant, "participantId" | "role">[];
 }
 
 export interface CreateCalendarResponse {
@@ -21,4 +21,12 @@ export interface InviteToCalendarRequest {
 
 export interface GetCalendarListResponse {
   calendars: CalendarInfo[];
+}
+
+export interface GetCalendarByIdResponse {
+  calendarId: number;
+  title: string;
+  memberRole: CalendarRole;
+  memberNickname: string;
+  participants: CalendarParticipant[];
 }

--- a/src/entities/calendar/api/types.ts
+++ b/src/entities/calendar/api/types.ts
@@ -1,4 +1,4 @@
-import type { CalendarParticipant } from "../model";
+import type { CalendarInfo, CalendarParticipant } from "../model";
 
 export interface CreateCalendarRequest {
   title: string;
@@ -21,9 +21,4 @@ export interface InviteToCalendarRequest {
 
 export interface GetCalendarListResponse {
   calendars: CalendarInfo[];
-}
-
-interface CalendarInfo {
-  calendarId: number;
-  title: string;
 }

--- a/src/entities/calendar/api/types.ts
+++ b/src/entities/calendar/api/types.ts
@@ -1,0 +1,29 @@
+import type { CalendarParticipant } from "../model";
+
+export interface CreateCalendarRequest {
+  title: string;
+  participants: CalendarParticipant[];
+}
+
+export interface CreateCalendarResponse {
+  calendarId: number;
+  title: string;
+}
+
+export interface UpdateCalendarRequest {
+  title: string;
+  nickname: string;
+}
+
+export interface InviteToCalendarRequest {
+  memberId: number;
+}
+
+export interface GetCalendarListResponse {
+  calendars: CalendarInfo[];
+}
+
+interface CalendarInfo {
+  calendarId: number;
+  title: string;
+}

--- a/src/entities/calendar/index.ts
+++ b/src/entities/calendar/index.ts
@@ -1,2 +1,3 @@
 export * from "./model";
 export * from "./api";
+export * from "./model/store";

--- a/src/entities/calendar/model/store.ts
+++ b/src/entities/calendar/model/store.ts
@@ -1,0 +1,24 @@
+import { create } from "zustand";
+import type { CalendarInfo } from "./types";
+
+interface CalendarState {
+  calendars: CalendarInfo[];
+  setCalendars: (calendars: CalendarInfo[]) => void;
+  addCalendar: (calendar: CalendarInfo) => void;
+  updateCalendar: (updatedCalendar: CalendarInfo) => void;
+  deleteCalendar: (calendarId: number) => void;
+}
+
+export const useCalendarStore = create<CalendarState>((set) => ({
+  calendars: [],
+  setCalendars: (calendars) => set({ calendars }),
+  addCalendar: (calendar) => set((state) => ({ calendars: [...state.calendars, calendar] })),
+  updateCalendar: (updatedCalendar) =>
+    set((state) => ({
+      calendars: state.calendars.map((c) => (c.id === updatedCalendar.id ? updatedCalendar : c)),
+    })),
+  deleteCalendar: (calendarId) =>
+    set((state) => ({
+      calendars: state.calendars.filter((c) => c.id !== calendarId),
+    })),
+}));

--- a/src/entities/calendar/model/store.ts
+++ b/src/entities/calendar/model/store.ts
@@ -15,10 +15,10 @@ export const useCalendarStore = create<CalendarState>((set) => ({
   addCalendar: (calendar) => set((state) => ({ calendars: [...state.calendars, calendar] })),
   updateCalendar: (updatedCalendar) =>
     set((state) => ({
-      calendars: state.calendars.map((c) => (c.id === updatedCalendar.id ? updatedCalendar : c)),
+      calendars: state.calendars.map((c) => (c.calendarId === updatedCalendar.calendarId ? updatedCalendar : c)),
     })),
   deleteCalendar: (calendarId) =>
     set((state) => ({
-      calendars: state.calendars.filter((c) => c.id !== calendarId),
+      calendars: state.calendars.filter((c) => c.calendarId !== calendarId),
     })),
 }));

--- a/src/entities/calendar/model/types.ts
+++ b/src/entities/calendar/model/types.ts
@@ -1,5 +1,5 @@
 export interface ScheduleCalendar {
-  id: number;
+  calendarId: number;
   title: string;
   participants: CalendarParticipant[];
 }

--- a/src/entities/calendar/model/types.ts
+++ b/src/entities/calendar/model/types.ts
@@ -2,8 +2,13 @@ import type { Member } from "@/entities/member";
 
 export interface ScheduleCalendar {
   id: number;
-  name: string;
+  title: string;
   participants: CalendarParticipant[];
+}
+
+export interface CalendarInfo {
+  id: number;
+  title: string;
 }
 
 export interface CalendarParticipant extends Member {

--- a/src/entities/calendar/model/types.ts
+++ b/src/entities/calendar/model/types.ts
@@ -1,5 +1,3 @@
-import type { Member } from "@/entities/member";
-
 export interface ScheduleCalendar {
   id: number;
   title: string;
@@ -11,8 +9,9 @@ export interface CalendarInfo {
   title: string;
 }
 
-export interface CalendarParticipant extends Member {
+export interface CalendarParticipant {
+  memberId: number;
   role: CalendarRole;
 }
 
-export type CalendarRole = "OWNER" | "VIEWER" | "EDITOR";
+export type CalendarRole = "OWNER" | "VIEW" | "EDIT";

--- a/src/entities/calendar/model/types.ts
+++ b/src/entities/calendar/model/types.ts
@@ -10,8 +10,11 @@ export interface CalendarInfo {
 }
 
 export interface CalendarParticipant {
-  memberId: number;
+  participantId: number;
+  nickname: string;
   role: CalendarRole;
+  email: string;
+  me: boolean;
 }
 
 export type CalendarRole = "OWNER" | "VIEW" | "EDIT";

--- a/src/entities/calendar/model/types.ts
+++ b/src/entities/calendar/model/types.ts
@@ -7,7 +7,7 @@ export interface ScheduleCalendar {
 }
 
 export interface CalendarInfo {
-  id: number;
+  calendarId: number;
   title: string;
 }
 

--- a/src/features/create-calendar/ui/index.tsx
+++ b/src/features/create-calendar/ui/index.tsx
@@ -57,14 +57,15 @@ export const CreateCalendar = () => {
   });
 
   const handleSelectMember = (member: Member) => {
-    const existingMembers = fields.map((field) => field.memberId);
+    const existingMembers = fields.map((field) => field.participantId);
 
     if (!existingMembers.includes(member.id)) {
       append({
-        memberId: member.id,
+        participantId: member.id,
         role: "VIEW",
         nickname: member.nickname,
         email: member.email,
+        me: false,
       });
     }
   };
@@ -83,8 +84,8 @@ export const CreateCalendar = () => {
     try {
       const submissionData = {
         title: data.title,
-        participants: data.participants.map(({ memberId, role }) => ({
-          memberId,
+        participants: data.participants.map(({ participantId, role }) => ({
+          participantId,
           role,
         })),
       };

--- a/src/features/create-calendar/ui/index.tsx
+++ b/src/features/create-calendar/ui/index.tsx
@@ -3,7 +3,13 @@ import { Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
 
-import { type CalendarParticipant, type CalendarRole, type ScheduleCalendar, calendarApi } from "@/entities/calendar";
+import {
+  type CalendarParticipant,
+  type CalendarRole,
+  type ScheduleCalendar,
+  calendarApi,
+  useCalendarStore,
+} from "@/entities/calendar";
 import type { Member } from "@/entities/member/model";
 import { ROLE_OPTIONS } from "@/shared/const";
 import {
@@ -38,6 +44,8 @@ type CreateCalendarFormData = Omit<ScheduleCalendar, "id">;
 export const CreateCalendar = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
+
+  const { addCalendar } = useCalendarStore();
 
   const form = useForm<CreateCalendarFormData>({
     defaultValues: {
@@ -80,6 +88,7 @@ export const CreateCalendar = () => {
     try {
       const response = await calendarApi.createCalendar(data);
       devLogger.log("캘린더 생성:", data);
+      addCalendar({ id: response.calendarId, title: response.title });
       form.reset();
       setIsOpen(false);
     } catch (error) {

--- a/src/features/create-calendar/ui/index.tsx
+++ b/src/features/create-calendar/ui/index.tsx
@@ -3,13 +3,7 @@ import { Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
 
-import {
-  type CalendarParticipant,
-  type CalendarRole,
-  type ScheduleCalendar,
-  calendarApi,
-  useCalendarStore,
-} from "@/entities/calendar";
+import { type CalendarParticipant, type CalendarRole, calendarApi, useCalendarStore } from "@/entities/calendar";
 import type { Member } from "@/entities/member/model";
 import { ROLE_OPTIONS } from "@/shared/const";
 import {
@@ -35,7 +29,10 @@ import {
   SelectValue,
 } from "@/shared/ui";
 
-type CreateCalendarFormData = Omit<ScheduleCalendar, "id">;
+interface CreateCalendarFormData {
+  title: string;
+  participants: (CalendarParticipant & { nickname: string; email: string })[];
+}
 
 /**
  * 새로운 캘린더를 생성하는 다이얼로그 컴포넌트입니다.
@@ -60,17 +57,15 @@ export const CreateCalendar = () => {
   });
 
   const handleSelectMember = (member: Member) => {
-    const existingEmails = fields.map((field) => field.email);
+    const existingMembers = fields.map((field) => field.memberId);
 
-    if (!existingEmails.includes(member.email)) {
-      const newParticipant: CalendarParticipant = {
-        id: member.id,
-        email: member.email,
+    if (!existingMembers.includes(member.id)) {
+      append({
+        memberId: member.id,
+        role: "VIEW",
         nickname: member.nickname,
-        role: "VIEWER",
-      };
-
-      append(newParticipant);
+        email: member.email,
+      });
     }
   };
 
@@ -86,9 +81,16 @@ export const CreateCalendar = () => {
   const handleSubmit = async (data: CreateCalendarFormData) => {
     setIsSubmitting(true);
     try {
-      const response = await calendarApi.createCalendar(data);
-      devLogger.log("캘린더 생성:", data);
-      addCalendar({ id: response.calendarId, title: response.title });
+      const submissionData = {
+        title: data.title,
+        participants: data.participants.map(({ memberId, role }) => ({
+          memberId,
+          role,
+        })),
+      };
+      const response = await calendarApi.createCalendar(submissionData);
+      devLogger.log("캘린더 생성:", submissionData);
+      addCalendar({ calendarId: response.calendarId, title: response.title });
       form.reset();
       setIsOpen(false);
     } catch (error) {

--- a/src/features/create-calendar/ui/index.tsx
+++ b/src/features/create-calendar/ui/index.tsx
@@ -3,7 +3,7 @@ import { Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
 
-import type { CalendarParticipant, CalendarRole, ScheduleCalendar } from "@/entities/calendar";
+import { type CalendarParticipant, type CalendarRole, type ScheduleCalendar, calendarApi } from "@/entities/calendar";
 import type { Member } from "@/entities/member/model";
 import { ROLE_OPTIONS } from "@/shared/const";
 import {
@@ -41,7 +41,7 @@ export const CreateCalendar = () => {
 
   const form = useForm<CreateCalendarFormData>({
     defaultValues: {
-      name: "",
+      title: "",
       participants: [],
     },
   });
@@ -78,8 +78,9 @@ export const CreateCalendar = () => {
   const handleSubmit = async (data: CreateCalendarFormData) => {
     setIsSubmitting(true);
     try {
-      form.reset();
+      const response = await calendarApi.createCalendar(data);
       devLogger.log("캘린더 생성:", data);
+      form.reset();
       setIsOpen(false);
     } catch (error) {
       devLogger.error("캘린더 생성 실패:", error);
@@ -116,7 +117,7 @@ export const CreateCalendar = () => {
           <form onSubmit={form.handleSubmit(handleSubmit)} className="flex min-w-0 flex-1 flex-col space-y-6">
             <FormField
               control={form.control}
-              name="name"
+              name="title"
               rules={{ required: "캘린더 이름을 입력해주세요" }}
               render={({ field }) => (
                 <FormItem>
@@ -126,7 +127,7 @@ export const CreateCalendar = () => {
                       placeholder="캘린더 이름을 입력하세요"
                       {...field}
                       className={cn(
-                        form.formState.errors.name &&
+                        form.formState.errors.title &&
                           "border-[2px] border-notification-strong focus:border-notification-strong focus:ring-notification-strong",
                       )}
                     />

--- a/src/features/edit-calendar/ui/index.tsx
+++ b/src/features/edit-calendar/ui/index.tsx
@@ -1,4 +1,10 @@
-import { type CalendarRole, calendarApi, participantApi, useCalendarStore } from "@/entities/calendar";
+import {
+  type CalendarParticipant,
+  type CalendarRole,
+  calendarApi,
+  participantApi,
+  useCalendarStore,
+} from "@/entities/calendar";
 import type { Member } from "@/entities/member/model";
 import { ROLE_OPTIONS } from "@/shared/const";
 import { cn, devLogger } from "@/shared/lib";
@@ -36,15 +42,7 @@ interface EditableScheduleCalendar {
   title: string;
   memberRole: CalendarRole;
   memberNickname: string;
-  participants: EditCalendarScheduleCalendarParticipant[];
-}
-
-interface EditCalendarScheduleCalendarParticipant {
-  participantId: number;
-  nickname: string;
-  role: CalendarRole;
-  email: string;
-  me: boolean;
+  participants: CalendarParticipant[];
 }
 
 interface EditCalendarFormData {
@@ -66,7 +64,7 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isInviting, setIsInviting] = useState(false);
   const [error, setError] = useState<string | undefined>(undefined);
-  const [participants, setParticipants] = useState<EditCalendarScheduleCalendarParticipant[]>([]);
+  const [participants, setParticipants] = useState<CalendarParticipant[]>([]);
   const [showDeleteCalendar, setShowDeleteCalendar] = useState(false);
   const [showDeleteMember, setShowDeleteMember] = useState(false);
   const [selectedMembers, setSelectedMembers] = useState<Member[]>([]);
@@ -138,7 +136,7 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
       );
       await Promise.all(invitePromises);
 
-      const newParticipants: EditCalendarScheduleCalendarParticipant[] = selectedMembers.map((member) => ({
+      const newParticipants: CalendarParticipant[] = selectedMembers.map((member) => ({
         participantId: member.id,
         nickname: member.nickname,
         role: "VIEW" as CalendarRole,

--- a/src/features/edit-calendar/ui/index.tsx
+++ b/src/features/edit-calendar/ui/index.tsx
@@ -37,8 +37,9 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 
-interface EditableScheduleCalendar extends ScheduleCalendar {
+interface EditableScheduleCalendar extends Omit<ScheduleCalendar, "participants"> {
   nickname: string;
+  participants: (CalendarParticipant & { nickname: string; email: string })[];
 }
 
 interface EditCalendarFormData {
@@ -60,7 +61,7 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isInviting, setIsInviting] = useState(false);
   const [error, setError] = useState<string | undefined>(undefined);
-  const [participants, setParticipants] = useState<CalendarParticipant[]>([]);
+  const [participants, setParticipants] = useState<(CalendarParticipant & { nickname: string; email: string })[]>([]);
   const [showDeleteCalendar, setShowDeleteCalendar] = useState(false);
   const [showDeleteMember, setShowDeleteMember] = useState(false);
   const [selectedMembers, setSelectedMembers] = useState<Member[]>([]);
@@ -86,7 +87,7 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
       return {
         id: response.id,
         title: response.title,
-        participants: response.participants,
+        participants: response.participants, // This needs to be fixed in the API
         nickname: response.nickname,
       };
     } catch (err) {
@@ -138,11 +139,11 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
       );
       await Promise.all(invitePromises);
 
-      const newParticipants: CalendarParticipant[] = selectedMembers.map((member) => ({
-        id: member.id,
+      const newParticipants = selectedMembers.map((member) => ({
+        memberId: member.id,
         email: member.email,
         nickname: member.nickname,
-        role: "VIEWER", // 초대 시 기본 역할은 VIEWER로 가정
+        role: "VIEW" as const,
       }));
 
       setParticipants((prev) => [...prev, ...newParticipants]);
@@ -156,12 +157,12 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
     }
   };
 
-  const handleRoleChange = async (participantId: number, role: CalendarRole) => {
+  const handleRoleChange = async (memberId: number, role: CalendarRole) => {
     try {
       // TODO: 역할 변경 API 호출
 
       setParticipants((prev) =>
-        prev.map((participant) => (participant.id === participantId ? { ...participant, role } : participant)),
+        prev.map((participant) => (participant.memberId === memberId ? { ...participant, role } : participant)),
       );
     } catch (error) {
       console.error("역할 변경 실패:", error);
@@ -169,11 +170,11 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
     }
   };
 
-  const handleRemoveParticipant = async (participantId: number) => {
+  const handleRemoveParticipant = async (memberId: number) => {
     try {
       // TODO: 삭제 API 호출
 
-      setParticipants((prev) => prev.filter((participant) => participant.id !== participantId));
+      setParticipants((prev) => prev.filter((participant) => participant.memberId !== memberId));
     } catch (error) {
       console.error("참가자 삭제 실패:", error);
       // TODO: 에러 토스트 표시
@@ -346,7 +347,7 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
                   <ScrollArea className="max-h-80 rounded-lg border border-grayscale-400 p-3">
                     <div className="space-y-1 pr-1">
                       {participants.map((participant) => (
-                        <div key={participant.id} className="flex items-center gap-2 py-1">
+                        <div key={participant.memberId} className="flex items-center gap-2 py-1">
                           <div className="flex w-0 flex-1 flex-col">
                             <div
                               className="truncate text-grayscale-700 text-medium-r leading-7"
@@ -361,7 +362,7 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
 
                           <Select
                             value={participant.role}
-                            onValueChange={(value) => handleRoleChange(participant.id, value as CalendarRole)}
+                            onValueChange={(value) => handleRoleChange(participant.memberId, value as CalendarRole)}
                             disabled={participant.role === "OWNER"}
                           >
                             <SelectTrigger className="h-8 w-28">
@@ -381,7 +382,7 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
                             onOpenChange={setShowDeleteMember}
                             title="멤버 삭제"
                             description="멤버를 삭제하시겠습니까?"
-                            onConfirm={() => handleRemoveParticipant(participant.id)}
+                            onConfirm={() => handleRemoveParticipant(participant.memberId)}
                             variant="destructive"
                           >
                             <Button

--- a/src/features/edit-calendar/ui/index.tsx
+++ b/src/features/edit-calendar/ui/index.tsx
@@ -133,24 +133,24 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
 
     setIsInviting(true);
     try {
-      // TODO: 여러 멤버 초대 API 호출
+      const invitePromises = selectedMembers.map((member) =>
+        calendarApi.inviteToCalendar(calendarId, { memberId: member.id }),
+      );
+      await Promise.all(invitePromises);
 
-      // API 성공 후에만 UI 업데이트
       const newParticipants: CalendarParticipant[] = selectedMembers.map((member) => ({
         id: member.id,
         email: member.email,
         nickname: member.nickname,
-        role: "VIEWER",
+        role: "VIEWER", // 초대 시 기본 역할은 VIEWER로 가정
       }));
 
       setParticipants((prev) => [...prev, ...newParticipants]);
       setSelectedMembers([]);
-
-      // TODO: 성공 토스트 표시
+      toast("멤버 초대가 완료되었습니다.");
     } catch (error) {
-      console.error("참가자 초대 실패:", error);
-      // TODO: 에러 토스트 표시
-      // UI 상태는 자동으로 원래대로 유지됨 (API 실패 시 아무것도 변경하지 않음)
+      devLogger.error("참가자 초대 실패:", error);
+      toast("멤버 초대 실패.");
     } finally {
       setIsInviting(false);
     }

--- a/src/features/edit-calendar/ui/index.tsx
+++ b/src/features/edit-calendar/ui/index.tsx
@@ -3,6 +3,7 @@ import {
   type CalendarRole,
   type ScheduleCalendar,
   calendarApi,
+  participantApi,
   useCalendarStore,
 } from "@/entities/calendar";
 import type { Member } from "@/entities/member/model";
@@ -159,25 +160,25 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
 
   const handleRoleChange = async (memberId: number, role: CalendarRole) => {
     try {
-      // TODO: 역할 변경 API 호출
-
+      await participantApi.modifyRole(calendarId, memberId, role);
       setParticipants((prev) =>
         prev.map((participant) => (participant.memberId === memberId ? { ...participant, role } : participant)),
       );
+      toast("멤버 역할이 변경되었습니다.");
     } catch (error) {
-      console.error("역할 변경 실패:", error);
-      // TODO: 에러 토스트 표시
+      devLogger.error("역할 변경 실패:", error);
+      toast("멤버 역할 변경에 실패했습니다.");
     }
   };
 
   const handleRemoveParticipant = async (memberId: number) => {
     try {
-      // TODO: 삭제 API 호출
-
+      await participantApi.deleteParticipant(calendarId, memberId);
       setParticipants((prev) => prev.filter((participant) => participant.memberId !== memberId));
+      toast("멤버가 삭제되었습니다.");
     } catch (error) {
-      console.error("참가자 삭제 실패:", error);
-      // TODO: 에러 토스트 표시
+      devLogger.error("참가자 삭제 실패:", error);
+      toast("멤버 삭제에 실패했습니다.");
     }
   };
 

--- a/src/features/edit-calendar/ui/index.tsx
+++ b/src/features/edit-calendar/ui/index.tsx
@@ -157,11 +157,13 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
     }
   };
 
-  const handleRoleChange = async (memberId: number, role: CalendarRole) => {
+  const handleRoleChange = async (participantId: number, role: CalendarRole) => {
     try {
-      await participantApi.modifyRole(calendarId, memberId, role);
+      await participantApi.modifyRole(calendarId, participantId, role);
       setParticipants((prev) =>
-        prev.map((participant) => (participant.participantId === memberId ? { ...participant, role } : participant)),
+        prev.map((participant) =>
+          participant.participantId === participantId ? { ...participant, role } : participant,
+        ),
       );
       toast("멤버 역할이 변경되었습니다.");
     } catch (error) {
@@ -170,10 +172,10 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
     }
   };
 
-  const handleRemoveParticipant = async (memberId: number) => {
+  const handleRemoveParticipant = async (participantId: number) => {
     try {
-      await participantApi.deleteParticipant(calendarId, memberId);
-      setParticipants((prev) => prev.filter((participant) => participant.participantId !== memberId));
+      await participantApi.deleteParticipant(calendarId, participantId);
+      setParticipants((prev) => prev.filter((participant) => participant.participantId !== participantId));
       toast("멤버가 삭제되었습니다.");
     } catch (error) {
       devLogger.error("참가자 삭제 실패:", error);

--- a/src/features/edit-calendar/ui/index.tsx
+++ b/src/features/edit-calendar/ui/index.tsx
@@ -1,11 +1,4 @@
-import {
-  type CalendarParticipant,
-  type CalendarRole,
-  type ScheduleCalendar,
-  calendarApi,
-  participantApi,
-  useCalendarStore,
-} from "@/entities/calendar";
+import { type CalendarRole, calendarApi, participantApi, useCalendarStore } from "@/entities/calendar";
 import type { Member } from "@/entities/member/model";
 import { ROLE_OPTIONS } from "@/shared/const";
 import { cn, devLogger } from "@/shared/lib";
@@ -38,9 +31,20 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 
-interface EditableScheduleCalendar extends Omit<ScheduleCalendar, "participants"> {
+interface EditableScheduleCalendar {
+  calenadarId: number;
+  title: string;
+  memberRole: CalendarRole;
+  memberNickname: string;
+  participants: EditCalendarScheduleCalendarParticipant[];
+}
+
+interface EditCalendarScheduleCalendarParticipant {
+  participantId: number;
   nickname: string;
-  participants: (CalendarParticipant & { nickname: string; email: string })[];
+  role: CalendarRole;
+  email: string;
+  me: boolean;
 }
 
 interface EditCalendarFormData {
@@ -62,7 +66,7 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isInviting, setIsInviting] = useState(false);
   const [error, setError] = useState<string | undefined>(undefined);
-  const [participants, setParticipants] = useState<(CalendarParticipant & { nickname: string; email: string })[]>([]);
+  const [participants, setParticipants] = useState<EditCalendarScheduleCalendarParticipant[]>([]);
   const [showDeleteCalendar, setShowDeleteCalendar] = useState(false);
   const [showDeleteMember, setShowDeleteMember] = useState(false);
   const [selectedMembers, setSelectedMembers] = useState<Member[]>([]);
@@ -84,13 +88,7 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
 
   const fetchCalendarData = useCallback(async (id: number): Promise<EditableScheduleCalendar> => {
     try {
-      const response = await calendarApi.getCalendarById(id);
-      return {
-        id: response.id,
-        title: response.title,
-        participants: response.participants, // This needs to be fixed in the API
-        nickname: response.nickname,
-      };
+      return await calendarApi.getCalendarById(id);
     } catch (err) {
       throw new Error("캘린더 정보를 불러오는데 실패했습니다.");
     }
@@ -109,7 +107,7 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
         const data = await fetchCalendarData(calendarId);
         form.reset({
           title: data.title || "",
-          nickname: data.nickname || "",
+          nickname: data.memberNickname || "",
         });
         setParticipants(data.participants || []);
       } catch (err) {
@@ -140,11 +138,12 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
       );
       await Promise.all(invitePromises);
 
-      const newParticipants = selectedMembers.map((member) => ({
-        memberId: member.id,
-        email: member.email,
+      const newParticipants: EditCalendarScheduleCalendarParticipant[] = selectedMembers.map((member) => ({
+        participantId: member.id,
         nickname: member.nickname,
-        role: "VIEW" as const,
+        role: "VIEW" as CalendarRole,
+        email: member.email,
+        me: false,
       }));
 
       setParticipants((prev) => [...prev, ...newParticipants]);
@@ -162,7 +161,7 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
     try {
       await participantApi.modifyRole(calendarId, memberId, role);
       setParticipants((prev) =>
-        prev.map((participant) => (participant.memberId === memberId ? { ...participant, role } : participant)),
+        prev.map((participant) => (participant.participantId === memberId ? { ...participant, role } : participant)),
       );
       toast("멤버 역할이 변경되었습니다.");
     } catch (error) {
@@ -174,7 +173,7 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
   const handleRemoveParticipant = async (memberId: number) => {
     try {
       await participantApi.deleteParticipant(calendarId, memberId);
-      setParticipants((prev) => prev.filter((participant) => participant.memberId !== memberId));
+      setParticipants((prev) => prev.filter((participant) => participant.participantId !== memberId));
       toast("멤버가 삭제되었습니다.");
     } catch (error) {
       devLogger.error("참가자 삭제 실패:", error);
@@ -348,7 +347,7 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
                   <ScrollArea className="max-h-80 rounded-lg border border-grayscale-400 p-3">
                     <div className="space-y-1 pr-1">
                       {participants.map((participant) => (
-                        <div key={participant.memberId} className="flex items-center gap-2 py-1">
+                        <div key={participant.participantId} className="flex items-center gap-2 py-1">
                           <div className="flex w-0 flex-1 flex-col">
                             <div
                               className="truncate text-grayscale-700 text-medium-r leading-7"
@@ -363,7 +362,9 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
 
                           <Select
                             value={participant.role}
-                            onValueChange={(value) => handleRoleChange(participant.memberId, value as CalendarRole)}
+                            onValueChange={(value) =>
+                              handleRoleChange(participant.participantId, value as CalendarRole)
+                            }
                             disabled={participant.role === "OWNER"}
                           >
                             <SelectTrigger className="h-8 w-28">
@@ -383,7 +384,7 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
                             onOpenChange={setShowDeleteMember}
                             title="멤버 삭제"
                             description="멤버를 삭제하시겠습니까?"
-                            onConfirm={() => handleRemoveParticipant(participant.memberId)}
+                            onConfirm={() => handleRemoveParticipant(participant.participantId)}
                             variant="destructive"
                           >
                             <Button

--- a/src/features/edit-calendar/ui/index.tsx
+++ b/src/features/edit-calendar/ui/index.tsx
@@ -1,7 +1,13 @@
-import type { CalendarParticipant, CalendarRole, ScheduleCalendar } from "@/entities/calendar";
+import {
+  type CalendarParticipant,
+  type CalendarRole,
+  type ScheduleCalendar,
+  calendarApi,
+  useCalendarStore,
+} from "@/entities/calendar";
 import type { Member } from "@/entities/member/model";
 import { ROLE_OPTIONS } from "@/shared/const";
-import { cn } from "@/shared/lib";
+import { cn, devLogger } from "@/shared/lib";
 import {
   Button,
   ConfirmDialog,
@@ -29,13 +35,14 @@ import {
 import { PenSquare, Trash2, User, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
+import { toast } from "sonner";
 
 interface EditableScheduleCalendar extends ScheduleCalendar {
   nickname: string;
 }
 
 interface EditCalendarFormData {
-  name: string;
+  title: string;
   nickname: string;
 }
 
@@ -58,9 +65,11 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
   const [showDeleteMember, setShowDeleteMember] = useState(false);
   const [selectedMembers, setSelectedMembers] = useState<Member[]>([]);
 
+  const { updateCalendar, deleteCalendar } = useCalendarStore();
+
   const form = useForm<EditCalendarFormData>({
     defaultValues: {
-      name: "",
+      title: "",
       nickname: "",
     },
   });
@@ -73,27 +82,12 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
 
   const fetchCalendarData = useCallback(async (id: number): Promise<EditableScheduleCalendar> => {
     try {
-      // TODO: 실제 캘린더 조회 API 호출로 교체
-      await new Promise((resolve) => setTimeout(resolve, 500));
-
+      const response = await calendarApi.getCalendarById(id);
       return {
-        id,
-        name: "기존 캘린더 이름",
-        nickname: "내 이름",
-        participants: [
-          {
-            id: 1,
-            email: "owner@example.com",
-            nickname: "소유자",
-            role: "OWNER",
-          },
-          {
-            id: 2,
-            email: "editor@example.com",
-            nickname: "편집자",
-            role: "EDITOR",
-          },
-        ],
+        id: response.id,
+        title: response.title,
+        participants: response.participants,
+        nickname: response.nickname,
       };
     } catch (err) {
       throw new Error("캘린더 정보를 불러오는데 실패했습니다.");
@@ -101,7 +95,9 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
   }, []);
 
   useEffect(() => {
-    if (!isOpen || !calendarId) return;
+    if (!isOpen || !calendarId) {
+      return;
+    }
 
     const loadCalendarData = async () => {
       setIsLoading(true);
@@ -110,7 +106,7 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
       try {
         const data = await fetchCalendarData(calendarId);
         form.reset({
-          name: data.name || "",
+          title: data.title || "",
           nickname: data.nickname || "",
         });
         setParticipants(data.participants || []);
@@ -187,19 +183,20 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
   const handleSubmit = async (data: EditCalendarFormData) => {
     setIsSubmitting(true);
     try {
+      if (!calendarId) return;
+
       const updateData = {
-        name: data.name,
+        title: data.title,
         nickname: data.nickname,
       };
 
-      console.log(updateData);
-      // TODO: 캘린더 수정 API 호출(닉네임은 수정하지 않는다면 null을 넣거나 아예 nickname 필드 빼기)
+      await calendarApi.updateCalendar(calendarId, updateData);
+      updateCalendar({ calendarId, title: data.title });
 
       setIsOpen(false);
-      // TODO: 성공 토스트 표시
+      toast("캘린더가 성공적으로 수정되었습니다.");
     } catch (error) {
-      console.error("캘린더 수정 실패:", error);
-      // TODO: 에러 토스트 표시
+      devLogger.error("캘린더 수정 실패:", error);
     } finally {
       setIsSubmitting(false);
     }
@@ -212,19 +209,21 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
 
   const handleDelete = async () => {
     try {
-      // TODO: 캘린더 삭제 요청 API 호출
+      if (!calendarId) return;
+
+      await calendarApi.deleteCalendar(calendarId);
+      deleteCalendar(calendarId);
 
       setIsOpen(false);
-      // TODO: 성공 토스트 표시
+      toast("캘린더가 성공적으로 삭제되었습니다.");
     } catch (error) {
-      console.error("캘린더 삭제 실패:", error);
-      // TODO: 에러 토스트 표시
+      devLogger.error("캘린더 삭제 실패:", error);
     }
   };
 
   const handleOpenChange = (open: boolean) => {
     setIsOpen(open);
-    if (open) {
+    if (!open) {
       form.reset();
     }
   };
@@ -257,7 +256,7 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
             <form onSubmit={form.handleSubmit(handleSubmit)} className="flex min-w-0 flex-col space-y-6">
               <FormField
                 control={form.control}
-                name="name"
+                name="title"
                 rules={{ required: "캘린더 이름을 입력해주세요" }}
                 render={({ field }) => (
                   <FormItem>
@@ -267,7 +266,7 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
                         placeholder="캘린더 이름을 입력하세요"
                         {...field}
                         className={cn(
-                          form.formState.errors.name &&
+                          form.formState.errors.title &&
                             "border-[2px] border-notification-strong focus:border-notification-strong focus:ring-notification-strong",
                         )}
                       />
@@ -322,7 +321,7 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
                           className="flex items-center gap-2 rounded-lg border border-primary-main/20 bg-primary-main/5 p-3"
                         >
                           <div className="flex h-8 w-8 items-center justify-center rounded-full bg-grayscale-100">
-                            <User className="h-4 w-4 text-grayscale-600" />
+                            <User className="h-4 w-4" />
                           </div>
                           <div className="min-w-0 flex-1">
                             <div className="truncate text-grayscale-700 text-medium-r">{member.nickname}</div>
@@ -409,7 +408,7 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
                   onOpenChange={setShowDeleteCalendar}
                   title="캘린더 삭제"
                   description="캘린더를 삭제하면 모든 일정이 영구적으로 삭제됩니다. 캘린더를 삭제하려면 아래에 캘린더 이름을 똑같이 입력하세요."
-                  expectedText={form.watch("name") || ""}
+                  expectedText={form.watch("title") || ""}
                   onConfirm={handleDelete}
                 >
                   <Button

--- a/src/features/edit-calendar/ui/index.tsx
+++ b/src/features/edit-calendar/ui/index.tsx
@@ -32,7 +32,7 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 
 interface EditableScheduleCalendar {
-  calenadarId: number;
+  calendarId: number;
   title: string;
   memberRole: CalendarRole;
   memberNickname: string;

--- a/src/features/share-schedule/ui/index.tsx
+++ b/src/features/share-schedule/ui/index.tsx
@@ -1,10 +1,10 @@
-import type { ScheduleCalendar } from "@/entities/calendar";
+import { useCalendarStore } from "@/entities/calendar";
 import { cn } from "@/shared/lib";
 import type { RightSidebarViewType } from "@/shared/model";
 import { Button, ButtonGroup, Calendar, Popover, PopoverContent, PopoverTrigger, ScrollArea } from "@/shared/ui";
 import { format } from "date-fns";
 import { CalendarIcon, ChevronDown } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import type { ShareScheduleItemType } from "../lib";
 import { ShareScheduleItem } from "./ShareScheduleItem";
 import { ToggleCheckButton } from "./ToggleCheckButton";
@@ -29,7 +29,6 @@ export const ShareSchedule = ({ onSetView }: ShareScheduleProps) => {
   const [isStartCalendarOpen, setIsStartCalendarOpen] = useState(false);
   const [isEndCalendarOpen, setIsEndCalendarOpen] = useState(false);
   const [selectedSchedules, setSelectedSchedules] = useState<Set<string>>(new Set());
-  const [calendars, setCalendars] = useState<ScheduleCalendar[]>([]);
   const [schedules] = useState<ShareScheduleItemType[]>([
     {
       id: 1,
@@ -74,21 +73,7 @@ export const ShareSchedule = ({ onSetView }: ShareScheduleProps) => {
       endTime: "23:59",
     },
   ]);
-
-  useEffect(() => {
-    setCalendars([
-      {
-        id: 1,
-        name: "개인 캘린더",
-        participants: [],
-      },
-      {
-        id: 2,
-        name: "Scheduo 캘린더",
-        participants: [],
-      },
-    ]);
-  }, []);
+  const calendars = useCalendarStore((state) => state.calendars);
 
   const getScheduleKey = (scheduleId: number, date: string): string => {
     return `${scheduleId}|${date}`;
@@ -154,8 +139,8 @@ export const ShareSchedule = ({ onSetView }: ShareScheduleProps) => {
               >
                 {calendars.map((calendar) => {
                   return (
-                    <option key={calendar.id} value={calendar.name}>
-                      {calendar.name}
+                    <option key={calendar.calendarId} value={calendar.title}>
+                      {calendar.title}
                     </option>
                   );
                 })}

--- a/src/features/view-daily-schedule/ui/index.tsx
+++ b/src/features/view-daily-schedule/ui/index.tsx
@@ -59,7 +59,7 @@ export const DailySchedule = ({ selectedDate = new Date(), schedules = [], onSet
 
                   <div className="flex w-full items-center justify-between text-grayscale-500 text-medium-s">
                     <div className="truncate">{schedule.location}</div>
-                    <div>{schedule.calendar.name}</div>
+                    <div>{schedule.calendar.title}</div>
                   </div>
                 </div>
               </button>

--- a/src/shared/const/calendarConstants.ts
+++ b/src/shared/const/calendarConstants.ts
@@ -1,5 +1,5 @@
 export const ROLE_OPTIONS = [
   { label: "owner", value: "OWNER" },
-  { label: "can view", value: "VIEWER" },
-  { label: "can edit", value: "EDITOR" },
+  { label: "can view", value: "VIEW" },
+  { label: "can edit", value: "EDIT" },
 ];

--- a/src/widgets/LeftSidebar/ui/CalendarList.tsx
+++ b/src/widgets/LeftSidebar/ui/CalendarList.tsx
@@ -10,7 +10,7 @@ export const CalendarList = () => {
     const fetchCalendars = async () => {
       try {
         const response = await calendarApi.getCalendarList();
-        setCalendars(response.calendars.map((c) => ({ id: c.id, title: c.title })));
+        setCalendars(response.calendars);
       } catch (error) {
         console.error("Failed to fetch calendars:", error);
       }
@@ -23,14 +23,14 @@ export const CalendarList = () => {
     <div className="mt-2 space-y-3">
       {calendars.map((calendar) => (
         <div
-          key={calendar.id}
+          key={calendar.calendarId}
           className="flex h-9 flex-1 cursor-pointer items-center justify-between rounded-md px-3 hover:bg-grayscale-200"
-          onMouseEnter={() => setHoveredCalendarId(calendar.id)}
+          onMouseEnter={() => setHoveredCalendarId(calendar.calendarId)}
           onMouseLeave={() => setHoveredCalendarId(-1)}
         >
           <span className="truncate text-grayscale-500 text-medium-m">{calendar.title}</span>
-          <div className={`${hoveredCalendarId === calendar.id ? "opacity-100" : "size-0 opacity-0"}`}>
-            <EditCalendar calendarId={calendar.id} />
+          <div className={`${hoveredCalendarId === calendar.calendarId ? "opacity-100" : "size-0 opacity-0"}`}>
+            <EditCalendar calendarId={calendar.calendarId} />
           </div>
         </div>
       ))}

--- a/src/widgets/LeftSidebar/ui/CalendarList.tsx
+++ b/src/widgets/LeftSidebar/ui/CalendarList.tsx
@@ -1,37 +1,36 @@
+import { calendarApi, useCalendarStore } from "@/entities/calendar";
 import { EditCalendar } from "@/features/edit-calendar";
-import { useState } from "react";
-
-type CalendarInfo = {
-  calendarId: number;
-  title: string;
-};
-
-const calendarList = [
-  {
-    calendarId: 1,
-    title: "Personal Calendarddddddddddd",
-  },
-  {
-    calendarId: 2,
-    title: "Team Calendar",
-  },
-];
+import { useEffect, useState } from "react";
 
 export const CalendarList = () => {
+  const { calendars, setCalendars } = useCalendarStore();
   const [hoveredCalendarId, setHoveredCalendarId] = useState<number>(-1);
+
+  useEffect(() => {
+    const fetchCalendars = async () => {
+      try {
+        const response = await calendarApi.getCalendarList();
+        setCalendars(response.calendars.map((c) => ({ id: c.id, title: c.title })));
+      } catch (error) {
+        console.error("Failed to fetch calendars:", error);
+      }
+    };
+
+    fetchCalendars();
+  }, [setCalendars]);
 
   return (
     <div className="mt-2 space-y-3">
-      {calendarList.map((calendar: CalendarInfo) => (
+      {calendars.map((calendar) => (
         <div
-          key={calendar.calendarId}
+          key={calendar.id}
           className="flex h-9 flex-1 cursor-pointer items-center justify-between rounded-md px-3 hover:bg-grayscale-200"
-          onMouseEnter={() => setHoveredCalendarId(calendar.calendarId)}
+          onMouseEnter={() => setHoveredCalendarId(calendar.id)}
           onMouseLeave={() => setHoveredCalendarId(-1)}
         >
           <span className="truncate text-grayscale-500 text-medium-m">{calendar.title}</span>
-          <div className={`${hoveredCalendarId === calendar.calendarId ? "opacity-100" : "size-0 opacity-0"}`}>
-            <EditCalendar calendarId={calendar.calendarId} />
+          <div className={`${hoveredCalendarId === calendar.id ? "opacity-100" : "size-0 opacity-0"}`}>
+            <EditCalendar calendarId={calendar.id} />
           </div>
         </div>
       ))}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

 - #37 

## 📋 작업 요약

캘린더 목록 전역 상태 관리 및 캘린더 생성/수정/삭제/초대 기능 API 연동

## 🔍 세부 내용

1️⃣ 캘린더 목록 전역 상태 관리 (FSD 원칙 준수)

 - `useCalendarStore`(Zustand)를 생성하여 캘린더 목록을 전역 상태로 관리
   - 해당 store는 비즈니스 엔티티인 Calendar의 전역 상태 관리를 담당하므로 entities/calendar에 위치

2️⃣ 캘린더 생성 기능 연동

 - 캘린더 생성 API 호출 성공 시, `useCalendarStore`의 `addCalendar` 액션을 호출하여 새로 생성된 캘린더를 스토어의 calendars 전역 상태에 추가하도록 연동

3️⃣ 캘린더 수정 및 삭제 기능 연동

 - `src/features/edit-calendar/ui/index.tsx`에서 캘린더 조회, 수정, 삭제 기능을 백엔드 API와 연동
     - `fetchCalendarData` 함수에서 `calendarApi.getCalendarById`를 호출하여 캘린더 정보를 불러오도록 수정
     - `handleSubmit` 함수에서 `calendarApi.updateCalendar`를 호출하고, 성공 시 `useCalendarStore`의 `updateCalendar` 액션을 호출하여 캘린더 정보를 업데이트
     - `handleDelete` 함수에서 `calendarApi.deleteCalendar`를 호출하고, 성공 시 `useCalendarStore`의 `deleteCalendar` 액션을 호출하여 캘린더를 목록에서 제거 

4️⃣ 캘린더 멤버 초대 기능 연동

 - `src/features/edit-calendar/ui/index.tsx`의 `handleInviteAll` 함수에서 `calendarApi.inviteToCalendar`를 호출하여 선택된 멤버들을 캘린더에 초대하도록 연동

5️⃣ UI 연동 및 개선

 - `src/widgets/LeftSidebar/ui/CalendarList.tsx`에서 `useCalendarStore`를 사용하여 캘린더 목록을 불러오고 표시하도록 개선
 - 컴포넌트 마운트 시점에 `calendarApi.getCalendarList`를 통해 초기 캘린더 목록을 가져와 스토어에 설정하도록 구현
 - 일정 공유 컴포넌트에서 공유할 캘린더 목록 데이터로 전역 상태 캘린더를 갖고 와서 사용하도록 구현

## ❗ 미구현 사항

- 캘린더 초대 수락/거절

## 🤔 추후 개선을 고려해볼 사항

- Tanstack Query 도입을 통한 캘린더 서버 상태 관리
- 캘린더 초대 배치 처리 API 추가 및 사용