### PR TITLE
[Feat] requestLogIn에서 로그인을 위해 이동하는 URL에 redirectUri 추가

### DIFF
--- a/src/entities/auth/api/index.ts
+++ b/src/entities/auth/api/index.ts
@@ -3,8 +3,10 @@ import { devLogger } from "@/shared/lib";
 import { useAuthStore } from "@/shared/stores";
 
 export const requestLogIn = (provider: "google" | "kakao") => {
-  const redirectUri = `${window.location.origin}`;
-  window.location.href = `${import.meta.env.VITE_API_BASE_URL}/oauth2/authorization/${provider}?redirect_uri=${encodeURIComponent(redirectUri)}`;
+  const redirectUri = window.location.origin;
+  const url = new URL(`${import.meta.env.VITE_API_BASE_URL}/oauth2/authorization/${provider}`);
+  url.searchParams.set("redirect_uri", redirectUri);
+  window.location.href = url.href;
 };
 
 export const requestLogOut = () => {

--- a/src/entities/auth/api/index.ts
+++ b/src/entities/auth/api/index.ts
@@ -3,7 +3,8 @@ import { devLogger } from "@/shared/lib";
 import { useAuthStore } from "@/shared/stores";
 
 export const requestLogIn = (provider: "google" | "kakao") => {
-  window.location.href = `${import.meta.env.VITE_API_BASE_URL}/oauth2/authorization/${provider}`;
+  const redirectUri = `${window.location.origin}`;
+  window.location.href = `${import.meta.env.VITE_API_BASE_URL}/oauth2/authorization/${provider}?redirect_uri=${encodeURIComponent(redirectUri)}`;
 };
 
 export const requestLogOut = () => {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #56 

## 📋 작업 요약

`requestLogIn`에서 로그인 시 이동하는 URL에 쿼리 스트링 추가

## 🔍 세부 내용

수정 결과:

```typescript
export const requestLogIn = (provider: "google" | "kakao") => {
  const redirectUri = `${window.location.origin}`;
  window.location.href = `${import.meta.env.VITE_API_BASE_URL}/oauth2/authorization/${provider}?redirect_uri=${encodeURIComponent(redirectUri)}`;
};
```
