### PR TITLE
[Feat] SPA 라우팅을 위한 vercel.json 설정 추가

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #60 

## 🤔 추정 오류 원인

SPA를 서버에 배포했을 때, 사용자가 직접 특정 경로를 브라우저에 요청하면 서버는 해당 경로에 대응하는 HTML 파일을 찾으려고 시도하게 됩니다. 하지만, SPA는 하나의 html 파일(`index.html`) 파일만이 존재하기 때문에 요청한 경로에 해당하는 리소스를 찾을 수 없어서 404 NOT FOUND 에러가 떴던 것으로 추측됩니다.

## 📋 작업 요약

- `vercel.json`에 rewrites 설정 추가

## 🔍 세부 내용

### rewrites 설정 추가

프로젝트의 루트에 `vercel.json` 파일을 생성하고 아래와 같이 설정했습니다.

```json
{
  "rewrites": [
    { "source": "/(.*)", "destination": "/index.html" }
  ]
}
```

이렇게 설정을 해주면 사용자가 어떠한 경로를 요청하든 `index.html`으로 포워딩하여 정상적으로 요청한 페이지가 뜰 것으로 예상됩니다.

## 🔗 참고 자료
- [💥 Spa 배포 시 하위 라우터에서 발생하는 404 오류 해결하기](https://woodstock.hashnode.dev/spa-404)
- [Configuring projects with vercel.json](https://vercel.com/docs/project-configuration#rewrites)