### PR TITLE
[Fix] 로그인 직후의 API 호출에 Authorization 헤더가 포함되지 않는 문제 수정

### DIFF
--- a/src/pages/oauth-redirect/ui/index.tsx
+++ b/src/pages/oauth-redirect/ui/index.tsx
@@ -1,4 +1,5 @@
 import { memberApi } from "@/entities/member/api";
+import { axiosInstance } from "@/shared/api";
 import { devLogger } from "@/shared/lib";
 import { useAuthStore } from "@/shared/stores";
 import { useEffect } from "react";
@@ -35,6 +36,7 @@ export const OAuthRedirectPage = () => {
 
         setAuth(accessToken, refreshToken);
 
+        axiosInstance.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
         const user = await memberApi.getMyProfile();
         setUser(user);
 

--- a/src/widgets/LeftSidebar/ui/UserInfo.tsx
+++ b/src/widgets/LeftSidebar/ui/UserInfo.tsx
@@ -5,7 +5,7 @@ export const UserInfo = () => {
   const user = useAuthStore((state) => state.user);
 
   if (!user) {
-    return <div>사용자 정보를 불러올 수 없습니다.</div>;
+    return <div className="flex items-center justify-between p-4">사용자 정보를 불러올 수 없습니다.</div>;
   }
 
   return (


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #62 

## 📋 작업 요약

- 문제 상황: 배포 환경에서는 로그인 직후 보내는 요청(`/members/me`)에 Authorization 헤더 들어가지 않음
- 추측하는 원인: setAuth로 store에 accessToken을 저장하기 전에 `GET /members/me` API를 호출하는것으로 추정
- 해결: OAuth 페이지에서만 Authorization 헤더를 직접 설정하도록 수정
