### PR TITLE
[Fix] 캘린더 생성 시 participantId 대신 memberId 전송

### DIFF
--- a/src/entities/calendar/api/types.ts
+++ b/src/entities/calendar/api/types.ts
@@ -1,8 +1,13 @@
 import type { CalendarInfo, CalendarParticipant, CalendarRole } from "../model";
 
+interface CreateCalendarParticipant {
+  memberId: number;
+  role: CalendarRole;
+}
+
 export interface CreateCalendarRequest {
   title: string;
-  participants: Pick<CalendarParticipant, "participantId" | "role">[];
+  participants: CreateCalendarParticipant[];
 }
 
 export interface CreateCalendarResponse {

--- a/src/features/create-calendar/ui/index.tsx
+++ b/src/features/create-calendar/ui/index.tsx
@@ -85,7 +85,7 @@ export const CreateCalendar = () => {
       const submissionData = {
         title: data.title,
         participants: data.participants.map(({ participantId, role }) => ({
-          participantId,
+          memberId: participantId,
           role,
         })),
       };


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #37

## 📋 작업 요약

- 발생했던 문제: 캘린더 생성에서 멤버 추가 후 생성 시도하면 memberId는 필수라는 에러 메시지가 뜨며 생성이 안됨
- 발견한 원인: 캘린더 참여자 타입에서 아이디를 모두 `memberId`에서 `participantId`로 바꿨더니 백엔드 API의 요구사항과 일치하지 않아서 발생한 문제
- 해결: 캘린더 생성 API 호출 시 참가자 데이터에서 'participantId' 필드를 백엔드 요구사항에 맞춰 'memberId'로 변경하여 전송하도록 수정

