### PR TITLE
[Feat] 캘린더 초대 API 수정 & 캘린더 초대 수락/거절 API 연동

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "vcs": {
-    "enabled": false,
+    "enabled": true,
     "clientKind": "git",
-    "useIgnoreFile": false
+    "useIgnoreFile": true
   },
   "files": {
     "ignoreUnknown": false,

--- a/src/entities/calendar/api/calendarApi.ts
+++ b/src/entities/calendar/api/calendarApi.ts
@@ -21,7 +21,7 @@ export const calendarApi = {
   },
 
   inviteToCalendar: async (calendarId: number, data: InviteToCalendarRequest) => {
-    await axiosInstance.post(`/calendars/${calendarId}`, data);
+    await axiosInstance.post(`/calendars/${calendarId}/invite`, data);
   },
 
   getCalendarList: async (): Promise<GetCalendarListResponse> => {

--- a/src/features/view-notification/ui/NotificationItem.tsx
+++ b/src/features/view-notification/ui/NotificationItem.tsx
@@ -24,7 +24,9 @@ export const NotificationItem = ({ notification, onDelete }: NotificationItemPro
   };
 
   const handleInviteAction = async (action: "accept" | "decline") => {
-    if (!notification.data?.calendarId || typeof notification.data.calendarId !== "number") {
+    const { calendarId } = notification.data ?? {};
+
+    if (typeof calendarId !== "number") {
       devLogger.error("Invalid calendarId in notification data", notification.data);
       toast.error("알림 처리 중 오류가 발생했습니다.");
       return;
@@ -36,7 +38,7 @@ export const NotificationItem = ({ notification, onDelete }: NotificationItemPro
     };
 
     try {
-      await actionApi[action](notification.data.calendarId as number);
+      await actionApi[action](calendarId);
       onDelete(notification.id);
     } catch (error) {
       devLogger.error(`Failed to ${action} notification`, error);

--- a/src/features/view-notification/ui/NotificationItem.tsx
+++ b/src/features/view-notification/ui/NotificationItem.tsx
@@ -1,7 +1,9 @@
+import { calendarApi } from "@/entities/calendar";
 import type { Notification } from "@/entities/notification";
 import { devLogger } from "@/shared/lib";
 import { Button } from "@/shared/ui";
 import { X } from "lucide-react";
+import { toast } from "sonner";
 import { NOTIFICATION_TYPE_LABELS } from "../consts";
 import { getRelativeTime } from "../lib";
 
@@ -23,8 +25,13 @@ export const NotificationItem = ({ notification, onDelete }: NotificationItemPro
 
   const handleAccept = async (e: React.MouseEvent) => {
     e.stopPropagation();
+    if (!notification.data?.calendarId || typeof notification.data.calendarId !== "number") {
+      devLogger.error("Invalid calendarId in notification data", notification.data);
+      toast.error("알림 처리 중 오류가 발생했습니다.");
+      return;
+    }
     try {
-      // TODO: POST /calendars/{calendarId}/invite/accept API 연동
+      calendarApi.acceptInvite(notification.data.calendarId as number);
       devLogger.log(`Accepted notification ${notification.id}`);
       onDelete(notification.id);
     } catch (error) {
@@ -34,8 +41,13 @@ export const NotificationItem = ({ notification, onDelete }: NotificationItemPro
 
   const handleDecline = (e: React.MouseEvent) => {
     e.stopPropagation();
+    if (!notification.data?.calendarId || typeof notification.data.calendarId !== "number") {
+      devLogger.error("Invalid calendarId in notification data", notification.data);
+      toast.error("알림 처리 중 오류가 발생했습니다.");
+      return;
+    }
     try {
-      // TODO: POST /calendars/{calendarId}/invite/decline API 연동
+      calendarApi.rejectInvite(notification.data?.calendarId as number);
       devLogger.log(`Declined notification ${notification.id}`);
       onDelete(notification.id);
     } catch (error) {

--- a/src/features/view-notification/ui/NotificationItem.tsx
+++ b/src/features/view-notification/ui/NotificationItem.tsx
@@ -23,36 +23,35 @@ export const NotificationItem = ({ notification, onDelete }: NotificationItemPro
     }
   };
 
-  const handleAccept = async (e: React.MouseEvent) => {
-    e.stopPropagation();
+  const handleInviteAction = async (action: "accept" | "decline") => {
     if (!notification.data?.calendarId || typeof notification.data.calendarId !== "number") {
       devLogger.error("Invalid calendarId in notification data", notification.data);
       toast.error("알림 처리 중 오류가 발생했습니다.");
       return;
     }
+
+    const actionApi = {
+      accept: calendarApi.acceptInvite,
+      decline: calendarApi.rejectInvite,
+    };
+
     try {
-      calendarApi.acceptInvite(notification.data.calendarId as number);
-      devLogger.log(`Accepted notification ${notification.id}`);
+      await actionApi[action](notification.data.calendarId as number);
       onDelete(notification.id);
     } catch (error) {
-      devLogger.error("Failed to accept notification", error);
+      devLogger.error(`Failed to ${action} notification`, error);
+      toast.error("알림 처리 중 오류가 발생했습니다.");
     }
+  };
+
+  const handleAccept = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    handleInviteAction("accept");
   };
 
   const handleDecline = (e: React.MouseEvent) => {
     e.stopPropagation();
-    if (!notification.data?.calendarId || typeof notification.data.calendarId !== "number") {
-      devLogger.error("Invalid calendarId in notification data", notification.data);
-      toast.error("알림 처리 중 오류가 발생했습니다.");
-      return;
-    }
-    try {
-      calendarApi.rejectInvite(notification.data?.calendarId as number);
-      devLogger.log(`Declined notification ${notification.id}`);
-      onDelete(notification.id);
-    } catch (error) {
-      devLogger.error("Failed to decline notification", error);
-    }
+    handleInviteAction("decline");
   };
 
   return (


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #64 

## 📋 작업 요약

- 캘린더 초대 API 수정
- 캘린더 초대 수락/거절 API 연동

## 🔍 세부 내용

### 캘린더 초대 API 수정

- 문제: 캘린더 초대가 되지 않음. 
- 원인: 캘린더 초대 요청 URL이 잘못됨
- 해결: URL 수정(`/calendars/${calendarId}` => `/calendars/${calendarId}/invite`)
