### PR TITLE
[Fix] 멤버 검색 드롭다운에서 엔터 키가 의도치않게 동작하는 문제 수정

### DIFF
--- a/src/shared/ui/MemberSearchInput.tsx
+++ b/src/shared/ui/MemberSearchInput.tsx
@@ -101,6 +101,10 @@ export const MemberSearchInput = ({
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (searchResults.length === 0) {
+      return;
+    }
+
     switch (e.key) {
       case "ArrowDown":
         e.preventDefault();
@@ -113,7 +117,7 @@ export const MemberSearchInput = ({
       case "Enter": {
         e.preventDefault();
         const member = searchResults[highlightedIndex];
-        if (member && !excludeEmails.includes(member.email)) {
+        if (member) {
           handleSelectMember(member);
         }
         break;

--- a/src/shared/ui/MemberSearchInput.tsx
+++ b/src/shared/ui/MemberSearchInput.tsx
@@ -43,7 +43,8 @@ export const MemberSearchInput = ({
         setIsSearching(true);
         try {
           const result: SearchResult = await memberApi.searchMember(searchQuery.trim());
-          setSearchResults(result.users || []);
+          const filteredUsers = (result.users || []).filter((user) => !excludeEmails.includes(user.email));
+          setSearchResults(filteredUsers);
           setShowSearchResults(true);
           setHighlightedIndex(0);
         } catch (error) {
@@ -59,7 +60,7 @@ export const MemberSearchInput = ({
     }, 300);
 
     return () => clearTimeout(timeoutId);
-  }, [searchQuery]);
+  }, [searchQuery, excludeEmails]);
 
   // 외부 클릭 시 닫기
   useEffect(() => {
@@ -145,7 +146,6 @@ export const MemberSearchInput = ({
       {showSearchResults && searchResults.length > 0 && (
         <div className="absolute top-full z-50 mt-1 max-h-60 w-full overflow-auto rounded-lg border border-grayscale-300 bg-white shadow-lg">
           {searchResults.map((member, index) => {
-            const isExcluded = excludeEmails.includes(member.email);
             const isHighlighted = index === highlightedIndex;
 
             return (
@@ -153,13 +153,11 @@ export const MemberSearchInput = ({
                 ref={isHighlighted ? highlightedItemRef : null}
                 key={member.id}
                 type="button"
-                onClick={() => !isExcluded && handleSelectMember(member)}
+                onClick={() => handleSelectMember(member)}
                 onMouseEnter={() => setHighlightedIndex(index)}
-                disabled={isExcluded}
                 className={cn(
                   "flex w-full items-center gap-3 px-4 py-3 text-left transition-colors",
-                  isExcluded ? "cursor-not-allowed bg-grayscale-50 text-grayscale-400" : "cursor-pointer",
-                  isHighlighted && !isExcluded ? "bg-grayscale-100" : "hover:bg-grayscale-50",
+                  isHighlighted ? "bg-grayscale-100" : "hover:bg-grayscale-50",
                 )}
               >
                 <div className="flex h-8 w-8 items-center justify-center rounded-full bg-grayscale-100">
@@ -169,7 +167,6 @@ export const MemberSearchInput = ({
                   <div className="truncate text-grayscale-700 text-medium-r">{member.nickname}</div>
                   <div className="truncate text-grayscale-400 text-medium-s">{member.email}</div>
                 </div>
-                {isExcluded && <span className="text-grayscale-400 text-small">이미 추가됨</span>}
               </button>
             );
           })}

--- a/src/shared/ui/MemberSearchInput.tsx
+++ b/src/shared/ui/MemberSearchInput.tsx
@@ -1,5 +1,5 @@
 import { Loader2, User } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { type KeyboardEvent, useEffect, useRef, useState } from "react";
 import { memberApi } from "@/entities/member/api";
 import type { Member } from "@/entities/member/model";
 import { cn, devLogger } from "@/shared/lib";
@@ -18,7 +18,7 @@ interface SearchResult {
 
 /**
  * 멤버를 검색하고 선택할 수 있는 검색 입력 컴포넌트입니다.
- * 실시간 검색과 드롭다운 결과를 제공합니다.
+ * 실시간 검색, 키보드 탐색, 드롭다운 결과를 제공합니다.
  */
 export const MemberSearchInput = ({
   placeholder = "이메일을 입력하여 멤버를 검색하세요",
@@ -30,11 +30,13 @@ export const MemberSearchInput = ({
   const [searchResults, setSearchResults] = useState<Member[]>([]);
   const [isSearching, setIsSearching] = useState(false);
   const [showSearchResults, setShowSearchResults] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
 
   const inputRef = useRef<HTMLInputElement>(null);
   const searchContainerRef = useRef<HTMLDivElement>(null);
+  const highlightedItemRef = useRef<HTMLButtonElement>(null);
 
-  // 검색 디바운싱을 위한 useEffect
+  // 검색 디바운싱
   useEffect(() => {
     const timeoutId = setTimeout(async () => {
       if (searchQuery.trim().length >= 2) {
@@ -43,6 +45,7 @@ export const MemberSearchInput = ({
           const result: SearchResult = await memberApi.searchMember(searchQuery.trim());
           setSearchResults(result.users || []);
           setShowSearchResults(true);
+          setHighlightedIndex(0);
         } catch (error) {
           devLogger.error("멤버 검색 실패:", error);
           setSearchResults([]);
@@ -58,7 +61,7 @@ export const MemberSearchInput = ({
     return () => clearTimeout(timeoutId);
   }, [searchQuery]);
 
-  // 검색 결과 영역 외부 클릭 시 닫기
+  // 외부 클릭 시 닫기
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (searchContainerRef.current && !searchContainerRef.current.contains(event.target as Node)) {
@@ -70,18 +73,53 @@ export const MemberSearchInput = ({
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
+  // 하이라이트된 항목으로 스크롤
+  useEffect(() => {
+    if (showSearchResults && highlightedItemRef.current) {
+      highlightedItemRef.current.scrollIntoView({
+        block: "nearest",
+      });
+    }
+  }, [showSearchResults]);
+
   const handleSearchInputChange = (value: string) => {
     setSearchQuery(value);
   };
 
   const handleSelectMember = (member: Member) => {
     onSelectMember(member);
-
-    // 검색 초기화
     setSearchQuery("");
     setSearchResults([]);
     setShowSearchResults(false);
     inputRef.current?.focus();
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (!showSearchResults || searchResults.length === 0) {
+      if (e.key === "Escape") {
+        setShowSearchResults(false);
+      }
+      return;
+    }
+
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setHighlightedIndex((prev) => (prev + 1) % searchResults.length);
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setHighlightedIndex((prev) => (prev - 1 + searchResults.length) % searchResults.length);
+        break;
+      case "Enter": {
+        e.preventDefault();
+        const member = searchResults[highlightedIndex];
+        if (member && !excludeEmails.includes(member.email)) {
+          handleSelectMember(member);
+        }
+        break;
+      }
+    }
   };
 
   return (
@@ -97,6 +135,7 @@ export const MemberSearchInput = ({
               setShowSearchResults(true);
             }
           }}
+          onKeyDown={handleKeyDown}
         />
         {isSearching && (
           <div className="-translate-y-1/2 absolute top-1/2 right-3">
@@ -105,23 +144,24 @@ export const MemberSearchInput = ({
         )}
       </div>
 
-      {/* 검색 결과 드롭다운 */}
       {showSearchResults && searchResults.length > 0 && (
         <div className="absolute top-full z-50 mt-1 max-h-60 w-full overflow-auto rounded-lg border border-grayscale-300 bg-white shadow-lg">
-          {searchResults.map((member) => {
+          {searchResults.map((member, index) => {
             const isExcluded = excludeEmails.includes(member.email);
+            const isHighlighted = index === highlightedIndex;
 
             return (
               <button
+                ref={isHighlighted ? highlightedItemRef : null}
                 key={member.id}
                 type="button"
                 onClick={() => !isExcluded && handleSelectMember(member)}
+                onMouseEnter={() => setHighlightedIndex(index)}
                 disabled={isExcluded}
                 className={cn(
                   "flex w-full items-center gap-3 px-4 py-3 text-left transition-colors",
-                  isExcluded
-                    ? "cursor-not-allowed bg-grayscale-50 text-grayscale-400"
-                    : "cursor-pointer hover:bg-grayscale-50",
+                  isExcluded ? "cursor-not-allowed bg-grayscale-50 text-grayscale-400" : "cursor-pointer",
+                  isHighlighted && !isExcluded ? "bg-grayscale-100" : "hover:bg-grayscale-50",
                 )}
               >
                 <div className="flex h-8 w-8 items-center justify-center rounded-full bg-grayscale-100">
@@ -138,7 +178,6 @@ export const MemberSearchInput = ({
         </div>
       )}
 
-      {/* 검색 결과가 없는 경우 */}
       {showSearchResults && searchResults.length === 0 && searchQuery.trim().length >= 2 && !isSearching && (
         <div className="absolute top-full z-50 mt-1 w-full rounded-lg border border-grayscale-300 bg-white p-4 text-center text-grayscale-400 text-medium-r shadow-lg">
           검색 결과가 없습니다

--- a/src/shared/ui/MemberSearchInput.tsx
+++ b/src/shared/ui/MemberSearchInput.tsx
@@ -75,12 +75,17 @@ export const MemberSearchInput = ({
 
   // 하이라이트된 항목으로 스크롤
   useEffect(() => {
-    if (showSearchResults && highlightedItemRef.current) {
+    if (
+      showSearchResults &&
+      highlightedItemRef.current &&
+      highlightedIndex >= 0 &&
+      highlightedIndex < searchResults?.length
+    ) {
       highlightedItemRef.current.scrollIntoView({
         block: "nearest",
       });
     }
-  }, [showSearchResults]);
+  }, [highlightedIndex, showSearchResults, searchResults]);
 
   const handleSearchInputChange = (value: string) => {
     setSearchQuery(value);

--- a/src/shared/ui/MemberSearchInput.tsx
+++ b/src/shared/ui/MemberSearchInput.tsx
@@ -100,13 +100,6 @@ export const MemberSearchInput = ({
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (!showSearchResults || searchResults.length === 0) {
-      if (e.key === "Escape") {
-        setShowSearchResults(false);
-      }
-      return;
-    }
-
     switch (e.key) {
       case "ArrowDown":
         e.preventDefault();


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #73 

## 📋 작업 요약

- 멤버 검색 결과 드롭다운에 키다운 이벤트 추가

## 🔍 세부 내용

### 엔터 키 문제 해결
- 문제 상황: 캘린더 생성/수정 창에서 멤버 검색 후 엔터 입력 시 검색한 멤버가 추가되기를 기대했지만, 실제로는 폼 제출이 됨
- 원인: form 태그 내부에 멤버 검색 컴포넌트(`MemberSearchInput.tsx`)가 존재해서 발생했던 문제. 멤버 초대 컴포넌트의 input에서 엔터 키를 누르면 form의 submit 이벤트가 트리거되어서 캘린더 수정 폼이 submit되고 있었음
- 해결: 멤버 초대 컴포넌트가 엔터 키 이벤트를 직접 처리하도록 키 다운 이벤트 핸들러 `handleKeyDown` 추가

### UX 향상
- 멤버 검색 결과 드롭다운에서 화살표 키(↑, ↓)로 멤버를 이동하고 Enter 키로 선택하도록 `handleKeyDown`에 키 처리 추가