### PR TITLE
[Refactor] 멤버 초대 API 수정

### DIFF
--- a/src/entities/calendar/api/types.ts
+++ b/src/entities/calendar/api/types.ts
@@ -21,7 +21,7 @@ export interface UpdateCalendarRequest {
 }
 
 export interface InviteToCalendarRequest {
-  memberId: number;
+  memberIds: number[];
 }
 
 export interface GetCalendarListResponse {

--- a/src/features/edit-calendar/ui/index.tsx
+++ b/src/features/edit-calendar/ui/index.tsx
@@ -146,7 +146,6 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
       setSelectedMembers([]);
     } catch (error) {
       devLogger.error("참가자 초대 실패:", error);
-      toast("멤버 초대가 실패했습니다.");
     } finally {
       setIsInviting(false);
     }
@@ -163,7 +162,6 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
       toast("멤버 역할이 변경되었습니다.");
     } catch (error) {
       devLogger.error("역할 변경 실패:", error);
-      toast("멤버 역할 변경에 실패했습니다.");
     }
   };
 

--- a/src/features/edit-calendar/ui/index.tsx
+++ b/src/features/edit-calendar/ui/index.tsx
@@ -131,10 +131,8 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
 
     setIsInviting(true);
     try {
-      const invitePromises = selectedMembers.map((member) =>
-        calendarApi.inviteToCalendar(calendarId, { memberId: member.id }),
-      );
-      await Promise.all(invitePromises);
+      const memberIds = selectedMembers.map((member) => member.id);
+      await calendarApi.inviteToCalendar(calendarId, { memberIds });
 
       const newParticipants: CalendarParticipant[] = selectedMembers.map((member) => ({
         participantId: member.id,
@@ -146,10 +144,9 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
 
       setParticipants((prev) => [...prev, ...newParticipants]);
       setSelectedMembers([]);
-      toast("멤버 초대가 완료되었습니다.");
     } catch (error) {
       devLogger.error("참가자 초대 실패:", error);
-      toast("멤버 초대 실패.");
+      toast("멤버 초대가 실패했습니다.");
     } finally {
       setIsInviting(false);
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #68

## 📋 작업 요약

- **API 호출 방식 변경**: 멤버 한 명당 한 번씩 초대 API 요청 => 멤버리스트로 묶어서 한 번만 멤버 초대 API 요청
- **사용자 피드백 제거**: 요청 성공 시 toast 알림 제거
