### PR TITLE
[Fix] 로그아웃 요청 시 비동기 처리 수정

### DIFF
--- a/src/entities/auth/api/index.ts
+++ b/src/entities/auth/api/index.ts
@@ -9,13 +9,16 @@ export const requestLogIn = (provider: "google" | "kakao") => {
   window.location.href = url.href;
 };
 
-export const requestLogOut = () => {
+export const requestLogOut = async () => {
   const { refreshToken, clearAuth } = useAuthStore.getState();
 
-  axiosInstance
-    .post("/auth/logout", {
+  try {
+    await axiosInstance.post("/auth/logout", {
       refreshToken,
-    })
-    .catch((error) => devLogger.error(error.message));
-  clearAuth();
+    });
+  } catch (error) {
+    devLogger.error(error);
+  } finally {
+    clearAuth();
+  }
 };

--- a/src/features/manage-settings/ui/index.tsx
+++ b/src/features/manage-settings/ui/index.tsx
@@ -31,8 +31,8 @@ export const ManageSettings = () => {
     }
   };
 
-  const handleLogOut = () => {
-    requestLogOut();
+  const handleLogOut = async () => {
+    await requestLogOut();
     navigate("/login");
   };
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #66 

## 📋 작업 요약

- 문제:  로그아웃 API 요청이 완료되기 전에 인증 정보가 삭제되어 `Authorization` 헤더가 누락
- 해결
  - `requestLogOut` 함수에 `async/await`를 적용하여 API 호출이 완료될 때까지 대기하도록 수정
  - `handleLogOut` 함수 또한 비동기 처리되도록 수정"