### PR TITLE
[Fix] 캘린더 수정 UI에서 OWNER가 아닌 경우 사용할 수 없는 버튼 비활성화 & PATCH API 요청 데이터 수정

### DIFF
--- a/src/entities/calendar/api/types.ts
+++ b/src/entities/calendar/api/types.ts
@@ -16,8 +16,8 @@ export interface CreateCalendarResponse {
 }
 
 export interface UpdateCalendarRequest {
-  title: string;
-  nickname: string;
+  title?: string;
+  nickname?: string;
 }
 
 export interface InviteToCalendarRequest {

--- a/src/features/edit-calendar/ui/index.tsx
+++ b/src/features/edit-calendar/ui/index.tsx
@@ -11,6 +11,7 @@ import {
   useUpdateCalendar,
   useUpdateParticipantRole,
 } from "@/entities/calendar";
+import type { UpdateCalendarRequest } from "@/entities/calendar/api/types";
 import type { Member } from "@/entities/member/model";
 import { ROLE_OPTIONS } from "@/shared/const";
 import { cn } from "@/shared/lib";
@@ -124,15 +125,27 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
   };
 
   const handleSubmit = (data: EditCalendarFormData) => {
-    if (!calendarId) return;
+    if (!calendarId || !calendarData) return;
+
+    const requestData: UpdateCalendarRequest = {};
+
+    if (data.nickname !== calendarData.memberNickname) {
+      requestData.nickname = data.nickname;
+    }
+
+    if (isOwner && data.title !== calendarData.title) {
+      requestData.title = data.title;
+    }
+
+    if (Object.keys(requestData).length === 0) {
+      setIsOpen(false);
+      return;
+    }
 
     updateMutation.mutate(
       {
         calendarId,
-        data: {
-          title: data.title,
-          nickname: data.nickname,
-        },
+        data: requestData,
       },
       {
         onSuccess: () => {

--- a/src/features/edit-calendar/ui/index.tsx
+++ b/src/features/edit-calendar/ui/index.tsx
@@ -68,6 +68,8 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
     },
   });
 
+  const isOwner = calendarData?.memberRole === "OWNER";
+
   const excludeEmails = useMemo(() => {
     const participantEmails = calendarData?.participants?.map((p) => p.email) || [];
     const selectedEmails = selectedMembers.map((m) => m.email);
@@ -201,6 +203,7 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
                       <Input
                         placeholder="캘린더 이름을 입력하세요"
                         {...field}
+                        disabled={!isOwner}
                         className={cn(
                           form.formState.errors.title &&
                             "border-[2px] border-notification-strong focus:border-notification-strong focus:ring-notification-strong",
@@ -241,11 +244,12 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
                     excludeEmails={excludeEmails}
                     onSelectMember={handleSelectMember}
                     className="flex-1"
+                    disabled={!isOwner}
                   />
                   <Button
                     type="button"
                     onClick={handleInviteAll}
-                    disabled={inviteToCalendarMutation.isPending || selectedMembers.length === 0}
+                    disabled={!isOwner || inviteToCalendarMutation.isPending || selectedMembers.length === 0}
                   >
                     {inviteToCalendarMutation.isPending ? "초대 중..." : `초대 (${selectedMembers.length})`}
                   </Button>
@@ -304,7 +308,7 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
                             onValueChange={(value) =>
                               handleRoleChange(participant.participantId, value as CalendarRole)
                             }
-                            disabled={participant.role === "OWNER"}
+                            disabled={!isOwner || participant.role === "OWNER"}
                           >
                             <SelectTrigger className="h-8 w-28">
                               <SelectValue />
@@ -332,7 +336,7 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
                               size="sm"
                               onClick={() => setShowDeleteMember(true)}
                               className="text-grayscale-400 hover:bg-transparent"
-                              disabled={participant.role === "OWNER"}
+                              disabled={!isOwner || participant.role === "OWNER"}
                             >
                               <Trash2 className="h-4 w-4" />
                             </Button>
@@ -344,25 +348,27 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
                 )}
               </div>
 
-              <div className="flex justify-end">
-                <TextConfirmDialog
-                  isOpen={showDeleteCalendar}
-                  onOpenChange={setShowDeleteCalendar}
-                  title="캘린더 삭제"
-                  description="캘린더를 삭제하면 모든 일정이 영구적으로 삭제됩니다. 캘린더를 삭제하려면 아래에 캘린더 이름을 똑같이 입력하세요."
-                  expectedText={form.watch("title") || ""}
-                  onConfirm={handleDelete}
-                >
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    className="text-grayscale-400 underline"
-                    onClick={() => setShowDeleteCalendar(true)}
+              {isOwner && (
+                <div className="flex justify-end">
+                  <TextConfirmDialog
+                    isOpen={showDeleteCalendar}
+                    onOpenChange={setShowDeleteCalendar}
+                    title="캘린더 삭제"
+                    description="캘린더를 삭제하면 모든 일정이 영구적으로 삭제됩니다. 캘린더를 삭제하려면 아래에 캘린더 이름을 똑같이 입력하세요."
+                    expectedText={form.watch("title") || ""}
+                    onConfirm={handleDelete}
                   >
-                    캘린더 삭제
-                  </Button>
-                </TextConfirmDialog>
-              </div>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      className="text-grayscale-400 underline"
+                      onClick={() => setShowDeleteCalendar(true)}
+                    >
+                      캘린더 삭제
+                    </Button>
+                  </TextConfirmDialog>
+                </div>
+              )}
 
               <DialogFooter>
                 <Button type="submit" disabled={updateMutation.isPending}>

--- a/src/features/edit-calendar/ui/index.tsx
+++ b/src/features/edit-calendar/ui/index.tsx
@@ -384,7 +384,7 @@ export const EditCalendar = ({ calendarId }: EditCalendarProps) => {
               )}
 
               <DialogFooter>
-                <Button type="submit" disabled={updateMutation.isPending}>
+                <Button type="submit" disabled={updateMutation.isPending || !form.formState.isDirty}>
                   {updateMutation.isPending ? "저장 중..." : "저장"}
                 </Button>
                 <Button type="button" variant="outline" onClick={handleCancel}>

--- a/src/shared/ui/MemberSearchInput.tsx
+++ b/src/shared/ui/MemberSearchInput.tsx
@@ -10,6 +10,7 @@ interface MemberSearchInputProps {
   excludeEmails?: string[];
   onSelectMember: (member: Member) => void;
   className?: string;
+  disabled?: boolean;
 }
 
 interface SearchResult {
@@ -25,6 +26,7 @@ export const MemberSearchInput = ({
   excludeEmails = [],
   onSelectMember,
   className,
+  disabled = false,
 }: MemberSearchInputProps) => {
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState<Member[]>([]);
@@ -139,6 +141,7 @@ export const MemberSearchInput = ({
             }
           }}
           onKeyDown={handleKeyDown}
+          disabled={disabled}
         />
         {isSearching && (
           <div className="-translate-y-1/2 absolute top-1/2 right-3">


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #79

## 📋 작업 요약

- 캘린더 수정 UI에서 OWNER가 아닌 경우 사용할 수 없는 버튼 비활성화
  - 캘린더 이름 수정
  - 캘린더 멤버 초대
  - 캘린더 멤버 역할 변경
- 캘린더 수정 요청 시 변경된 데이터만 request body에 포함
